### PR TITLE
Fix Awk and Bourne (Again) Shell comments.

### DIFF
--- a/cloc
+++ b/cloc
@@ -5183,20 +5183,20 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , ';.*$'   ],
                             ],
     'awk'                => [   
-                                [ 'remove_matches'      , '^\s*#'  ], 
-                                [ 'remove_inline'       , '#.*$'   ],
+                                [ 'remove_matches'      , '^\s*#.*$' ],
+                                [ 'remove_inline'       , '#.*$'     ],
                             ], 
     'bc'                 => [   
                                 [ 'remove_matches'      , '^\s*#'  ], 
                                 [ 'remove_inline'       , '#.*$'   ],
                             ], 
     'Bourne Again Shell' => [   
-                                [ 'remove_matches'      , '^\s*#'  ], 
-                                [ 'remove_inline'       , '#.*$'   ],
+                                [ 'remove_matches'      , '^\s*#.*$' ], 
+                                [ 'remove_inline'       , '#.*$'     ],
                             ], 
     'Bourne Shell'       => [   
-                                [ 'remove_matches'      , '^\s*#'  ], 
-                                [ 'remove_inline'       , '#.*$'   ],
+                                [ 'remove_matches'      , '^\s*#.*$' ], 
+                                [ 'remove_inline'       , '#.*$'     ],
                             ], 
     'C'                  => [   
                                 [ 'remove_matches'      , '^\s*//' ], # C99


### PR DESCRIPTION
There's something strange going on with `#` comments.  I'm not sure this is the right fix, but the results look right to me.

I tested with two files, `test1.sh`

    #!/bin/sh
    foo

and `test2.sh`

    #foo
    bar

Before my patch:

    ---------------------------------------------------------------------
    File                             blank        comment           code
    ---------------------------------------------------------------------
    test1.sh                             0             -1              3
    test2.sh                             0              0              2

And after:

    ---------------------------------------------------------------------
    File                             blank        comment           code
    ---------------------------------------------------------------------
    test1.sh                             0              0              2
    test2.sh                             0              1              1
