### PR TITLE
CSON format support.

### DIFF
--- a/cloc
+++ b/cloc
@@ -4841,6 +4841,7 @@ sub set_constants {                          # {{{1
             'cpp'         => 'C++'                   ,
             'cs'          => 'C#'                    ,
             'csh'         => 'C Shell'               ,
+            'cson'        => 'CSON'                  ,
             'css'         => "CSS"                   ,
             'ctl'         => 'Visual Basic'          ,
             'cu'          => 'CUDA'                  ,
@@ -5287,6 +5288,10 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , '//.*$'  ],
                             ],
     'Crystal Reports'    => [   [ 'remove_matches'      , '^\s*//' ], ],
+    'CSON'               => [
+                                [ 'remove_matches'      , '^\s*#'  ],
+                                [ 'remove_inline'       , '#.*$'   ],
+                            ],
     'D/dtrace'           => [ [ 'die' ,          ], ], # never called
     'D'                  => [
                                 [ 'remove_matches'      , '^\s*//' ],
@@ -6194,6 +6199,7 @@ sub set_constants {                          # {{{1
     'cpl'                          =>   0.50,
     'Crystal Reports'              =>   4.00,
     'csl'                          =>   1.63,
+    'CSON'                         =>   2.50,
     'csp'                          =>   1.51,
     'cssl'                         =>   1.74,
     'CSS'                          => 1.0,


### PR DESCRIPTION
JSON files are processed for Javascript.
CSON files should be processed for Coffeescript as well.

Note that comments are allowed in CSON files.
They are counted and reported in the following example:
```sh
 % cloc .                    
      10 text files.
      10 unique files.                              
       5 files ignored.

https://github.com/AlDanial/cloc v 1.65  T=0.05 s (127.7 files/s, 4108.1 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
CSON                             5              0             31            140
JSON                             1              0              0             22
-------------------------------------------------------------------------------
SUM:                             6              0             31            162
-------------------------------------------------------------------------------
```