### PR TITLE
Print `--help` to STDOUT instead of STDERR

### DIFF
--- a/cloc
+++ b/cloc
@@ -618,7 +618,7 @@ $opt_by_file  = 1 if defined  $opt_by_file_by_lang;
 my $CLOC_XSL = "cloc.xsl"; # created with --xsl
    $CLOC_XSL = "cloc-diff.xsl" if $opt_diff;
 die "\n" unless $getopt_success;
-die $usage if $opt_help;
+print $usage and exit if $opt_help;
 my %Exclude_Language = ();
    %Exclude_Language = map { $_ => 1 } split(/,/, $opt_exclude_lang)
         if $opt_exclude_lang;


### PR DESCRIPTION
By printing to STDOUT instead of STDERR it gets easier to manipulate the output, for example to pipe it to the pager (without having to redirect in the shell). It's 300+ lines so I needed some paging :smile_cat: 

The [code](https://github.com/AlDanial/cloc/blob/master/cloc#L713) for printing the help contents when sending in nothing is untouched (still an error).