### PR TITLE
Fixed issue with including files in directory with trailing slash 

### DIFF
--- a/Unix/cloc
+++ b/Unix/cloc
@@ -8831,7 +8831,7 @@ sub normalize_file_names {                   # {{{1
         }
         # Remove trailing / so it does not interfere with further regex code 
         # that does not expect it
-        $F_norm =~ s{/$}{}g;
+        $F_norm =~ s{/+$}{};
 
         $normalized{ $F_norm } = $F;
     }


### PR DESCRIPTION

Step to reproduce:

    Add to --exclude-list-file=file_list.txt directory with trailing slash.

Expected:

    Files in directory with trailing slash are ignored.

Actual result:

    Files in directory with trailing slash are not ignored.

