### PR TITLE
Add support for JavaScript in .es6 files

### DIFF
--- a/cloc
+++ b/cloc
@@ -5267,6 +5267,7 @@ sub set_constants {                          # {{{1
             'jcl'         => 'JCL'                   , # IBM Job Control Lang.
             'jl'          => 'Lisp/Julia'            ,
             'js'          => 'JavaScript'            ,
+            'es6'         => 'JavaScript'            ,
             'jsf'         => 'JavaServer Faces'      ,
             'jsx'         => 'JSX'                   ,
             'xhtml'       => 'XHTML'                 ,


### PR DESCRIPTION
I'm using sprockets-es6 in a Rails project for ES6 support, and I realized this tool isn't counting those files.