### PR TITLE
Use $(MAKE) instead of hard-coded make

### DIFF
--- a/Unix/Makefile
+++ b/Unix/Makefile
@@ -78,7 +78,7 @@ realclean: clean
 
 # Rule: man - Generate or update manual page
 man:
-	make -f pod2man.mk PACKAGE=$(PACKAGE) makeman
+	$(MAKE) -f pod2man.mk PACKAGE=$(PACKAGE) makeman
 
 # Rule: doc - Generate or update all documentation
 doc: man
@@ -120,7 +120,7 @@ install: install-bin install-man
 # Rule: install-test - for Maintainer only
 install-test:
 	rm -rf tmp
-	make DESTDIR=$$(pwd)/tmp prefix=/usr install
+	$(MAKE) DESTDIR=$$(pwd)/tmp prefix=/usr install
 	find tmp | sort
 
 # Rule: dist - for Maintainer only, make distribution


### PR DESCRIPTION
The OpenBSD ports system can be told that a software project needs GNU Make.
This works fine for the main Makefile but fails for generating the man page and the install test
as those targets hard code a call to make instead of `gmake` which stands for GNU Make on
OpenBSD.

This change introduces the $(MAKE) variable which defaults to the make that initiated the Makefile
instead of hard-coding a system wide command.