### PR TITLE
added to readme; Cloc functionality... all directories and subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,72 @@ C/C++ Header                     3             99            286            496
 SUM:                            13           4779           6907          31308
 -------------------------------------------------------------------------------
 </pre>
+**all Directories and Subdirectories**
+<pre>
+note, based off the basic format: for d in ./*/ ; do (cd "$d" && !!); done
+note, nesting happens at !!. put the command here again for each subdirectory level. 
+note, when finishing nesting !!, now becomes `cloc $(git ls-files)` -- see example.
+
+prompt> for three subdirectory file structure... 
+prompt> for d in ./*/ ; do (cd "$d" && for d in ./*/ ; do (cd "$d" && for d in ./*/ ; do (cd "$d" && cloc $(git ls-files)); done);); done); done
+
+      16 text files.
+      15 unique files.
+       3 files ignored.
+
+https://github.com/AlDanial/cloc v 1.65  T=0.23 s (57.1 files/s, 188914.0 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+C                               10           4680           6621          30812
+C/C++ Header                     3             99            286            496
+-------------------------------------------------------------------------------
+SUM:                            13           4779           6907          31308
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+      49 text files.
+      47 unique files.                              
+      13 files ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.10 s (399.5 files/s, 70409.4 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Python                          33           1226           1026           3017
+C                                4            327            337            888
+Markdown                         1             11              0             28
+YAML                             1              0              2             12
+-------------------------------------------------------------------------------
+SUM:                            39           1564           1365           3945
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+      57 text files.
+      57 unique files.                              
+      14 files ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.07 s (644.5 files/s, 84766.0 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Scala                           31            998            467           4124
+XML                              6              4             15            178
+Bourne Shell                     6             27              5            130
+HTML                             2             13              0             66
+YAML                             1              0              0             23
+-------------------------------------------------------------------------------
+SUM:                            46           1042            487           4521
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+Saving session...
+...saving history...truncating history files...
+...completed.
+</pre>
 
 **an archive**
 


### PR DESCRIPTION
If you need any clarification for this contribution I can be reached at email. 
MichaelDimmitt@icloud.com
a more in depth description/ example can be found here:
https://github.com/MichaelDimmitt/Bash_Directory_CLOC-Count-Lines-of-Program

program will work appropriately if too much nesting is performed. 
However, will miss submost levels if nesting does not exist to reach that level.
each time you nest the command, you access a level deeper into a directory.

This command that I am adding was very useful when I was evaluating a large number of projects on github. 
I would put them in a repository. Clone the repository down. And run the allSubdir's command to quickly see how large the different programs were before looking at any of the code.

nice overall program, cheers! Michael Dimmitt