### PR TITLE
added to readme; perform Cloc functionality on subLevel of a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ SUM:                            13           4779           6907          31308
 </pre>
 
 **sub directory**
-<!--Original Equation: for d in ./*/ ; do (cd "$d" && !!); done--><br>
-<!--note1: !! output is shown.. this is where user can nest to however many subdirectories they want.--><br>
-<!--note2: user would have to know how many subdirectories and nest accordingly.--><br>
-<!--note3: there is not a large amount of damage done to nesting too much.--><br>
 <pre>
+Original Equation: for d in ./*/ ; do (cd "$d" && !!); done
+note1: !! output is shown.. this is where user can nest to however many subdirectories they want.
+note2: user would have to know how many subdirectories and nest accordingly.
+note3: there is not a large amount of damage done to nesting too much.
 prompt>
-<!--performed in git bash on windows.-->
+note: performed in git bash on windows.
 for d in ./*/ ; do (cd "$d" && for d in ./*/ ; do (cd "$d" && cloc $(git ls-files)); done); done
 7 text files.
        7 unique files.                              

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ SUM:                            13           4779           6907          31308
 
 **each subdirectory of a particular directory**
 <pre>
-prompt> for d in ./*/ ; do (cd "$d" && echo "$d" && cloc $(git ls-files)); done
+prompt> for d in ./*/ ; do (cd "$d" && echo "$d" && cloc --vcs git); done
 ./ProjectName0/
 7 text files.
        7 unique files.                              

--- a/README.md
+++ b/README.md
@@ -85,6 +85,181 @@ SUM:                            13           4779           6907          31308
 -------------------------------------------------------------------------------
 </pre>
 
+**sub directory**
+<!--Original Equation: for d in ./*/ ; do (cd "$d" && !!); done--><br>
+<!--note1: !! output is shown.. this is where user can nest to however many subdirectories they want.--><br>
+<!--note2: user would have to know how many subdirectories and nest accordingly.--><br>
+<!--note3: there is not a large amount of damage done to nesting too much.--><br>
+<pre>
+prompt>
+<!--performed in git bash on windows.-->
+for d in ./*/ ; do (cd "$d" && for d in ./*/ ; do (cd "$d" && cloc $(git ls-files)); done); done
+7 text files.
+       7 unique files.                              
+       1 file ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.02 s (390.2 files/s, 25687.6 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+D                                4             61             32            251
+Markdown                         1              9              0             38
+make                             1              0              0              4
+-------------------------------------------------------------------------------
+SUM:                             6             70             32            293
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+       7 text files.
+       7 unique files.                              
+       0 files ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.02 s (293.0 files/s, 52107.1 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Go                               7            165            282            798
+-------------------------------------------------------------------------------
+SUM:                             7            165            282            798
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+      49 text files.
+      47 unique files.                              
+      13 files ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.10 s (399.5 files/s, 70409.4 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Python                          33           1226           1026           3017
+C                                4            327            337            888
+Markdown                         1             11              0             28
+YAML                             1              0              2             12
+-------------------------------------------------------------------------------
+SUM:                            39           1564           1365           3945
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+      37 text files.
+      37 unique files.                              
+      17 files ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.03 s (777.5 files/s, 48746.6 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+R                               17             76            320            461
+Markdown                         2            102              0            246
+YAML                             1              0              0             49
+-------------------------------------------------------------------------------
+SUM:                            20            178            320            756
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+      11 text files.
+      11 unique files.                              
+       4 files ignored.
+
+9 errors:
+Unable to read:  include/libs/catch/catch.hpp
+Unable to read:  include/libs/catch/catch_runner.hpp
+Unable to read:  include/libs/catch/catch_with_main.hpp
+Unable to read:  include/libs/exceptionpp
+Unable to read:  libs/exceptionpp
+Unable to read:  libs/stacktrace
+Unable to read:  tutorial/include/libs/exceptionpp
+Unable to read:  tutorial/libs/exceptionpp
+Unable to read:  tutorial/libs/stacktrace
+
+github.com/AlDanial/cloc v 1.68  T=0.03 s (270.5 files/s, 26546.4 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+C++                              4             94             25            407
+Markdown                         1             23              0             65
+C/C++ Header                     1             24             31             61
+make                             2             20              3             32
+-------------------------------------------------------------------------------
+SUM:                             8            161             59            565
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+     278 text files.
+     278 unique files.                                          
+       1 file ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.12 s (2377.4 files/s, 58619.0 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+JSON                           269              0              0           5884
+C                                3             58             20            431
+Python                           1             25             13            146
+Lua                              2             21              0             79
+Markdown                         1             31              0             44
+make                             1             17             24             37
+-------------------------------------------------------------------------------
+SUM:                           277            152             57           6621
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+Saving session...
+...saving history...truncating history files...
+...completed.
+-bash: cd: ./*/: No such file or directory
+Saving session...
+...saving history...truncating history files...
+...completed.
+-bash: cd: ./*/: No such file or directory
+Saving session...
+...saving history...truncating history files...
+...completed.
+      14 text files.
+      14 unique files.                              
+       4 files ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.01 s (724.3 files/s, 21800.4 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Scala                            9             56              1            209
+Markdown                         1             14              0             21
+-------------------------------------------------------------------------------
+SUM:                            10             70              1            230
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+      57 text files.
+      57 unique files.                              
+      14 files ignored.
+
+github.com/AlDanial/cloc v 1.68  T=0.07 s (644.5 files/s, 84766.0 lines/s)
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Scala                           31            998            467           4124
+XML                              6              4             15            178
+Bourne Shell                     6             27              5            130
+HTML                             2             13              0             66
+YAML                             1              0              0             23
+-------------------------------------------------------------------------------
+SUM:                            46           1042            487           4521
+-------------------------------------------------------------------------------
+Saving session...
+...saving history...truncating history files...
+...completed.
+Saving session...
+...saving history...truncating history files...
+...completed.
+</pre>
 **an archive**
 
 We'll pull cloc's source zip file from GitHub, then count the contents:

--- a/README.md
+++ b/README.md
@@ -85,17 +85,10 @@ SUM:                            13           4779           6907          31308
 -------------------------------------------------------------------------------
 </pre>
 
-**sub directory**
+**each subdirectory of a particular directory**
 <pre>
-Original Equation: for d in ./*/ ; do (cd "$d" && !!); done
-note1: !! output is shown.. this is where user can nest to however many subdirectories they want. 
-They will reach that level.
-note2: user would have to know how many subdirectories and nest accordingly.
-note3: a notification will show if there are no directories and you have nested too far.
+prompt> for d in ./*/ ; do (cd "$d" && cloc $(git ls-files)); done
 
-prompt>
-note: performed in git bash on windows.
-for d in ./*/ ; do (cd "$d" && for d in ./*/ ; do (cd "$d" && cloc $(git ls-files)); done); done
 7 text files.
        7 unique files.                              
        1 file ignored.

--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ SUM:                            13           4779           6907          31308
 **sub directory**
 <pre>
 Original Equation: for d in ./*/ ; do (cd "$d" && !!); done
-note1: !! output is shown.. this is where user can nest to however many subdirectories they want.
+note1: !! output is shown.. this is where user can nest to however many subdirectories they want. 
+They will reach that level.
 note2: user would have to know how many subdirectories and nest accordingly.
-note3: there is not a large amount of damage done to nesting too much.
+note3: a notification will show if there are no directories and you have nested too far.
+
 prompt>
 note: performed in git bash on windows.
 for d in ./*/ ; do (cd "$d" && for d in ./*/ ; do (cd "$d" && cloc $(git ls-files)); done); done

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ SUM:                            13           4779           6907          31308
 
 **each subdirectory of a particular directory**
 <pre>
-prompt> for d in ./*/ ; do (cd "$d" && cloc $(git ls-files)); done
-
+prompt> for d in ./*/ ; do (cd "$d" && echo "$d" && cloc $(git ls-files)); done
+./ProjectName0/
 7 text files.
        7 unique files.                              
        1 file ignored.
@@ -106,6 +106,7 @@ SUM:                             6             70             32            293
 Saving session...
 ...saving history...truncating history files...
 ...completed.
+./ProjectName1/
        7 text files.
        7 unique files.                              
        0 files ignored.
@@ -121,6 +122,7 @@ SUM:                             7            165            282            798
 Saving session...
 ...saving history...truncating history files...
 ...completed.
+./ProjectName2/
       49 text files.
       47 unique files.                              
       13 files ignored.
@@ -139,122 +141,7 @@ SUM:                            39           1564           1365           3945
 Saving session...
 ...saving history...truncating history files...
 ...completed.
-      37 text files.
-      37 unique files.                              
-      17 files ignored.
 
-github.com/AlDanial/cloc v 1.68  T=0.03 s (777.5 files/s, 48746.6 lines/s)
--------------------------------------------------------------------------------
-Language                     files          blank        comment           code
--------------------------------------------------------------------------------
-R                               17             76            320            461
-Markdown                         2            102              0            246
-YAML                             1              0              0             49
--------------------------------------------------------------------------------
-SUM:                            20            178            320            756
--------------------------------------------------------------------------------
-Saving session...
-...saving history...truncating history files...
-...completed.
-      11 text files.
-      11 unique files.                              
-       4 files ignored.
-
-9 errors:
-Unable to read:  include/libs/catch/catch.hpp
-Unable to read:  include/libs/catch/catch_runner.hpp
-Unable to read:  include/libs/catch/catch_with_main.hpp
-Unable to read:  include/libs/exceptionpp
-Unable to read:  libs/exceptionpp
-Unable to read:  libs/stacktrace
-Unable to read:  tutorial/include/libs/exceptionpp
-Unable to read:  tutorial/libs/exceptionpp
-Unable to read:  tutorial/libs/stacktrace
-
-github.com/AlDanial/cloc v 1.68  T=0.03 s (270.5 files/s, 26546.4 lines/s)
--------------------------------------------------------------------------------
-Language                     files          blank        comment           code
--------------------------------------------------------------------------------
-C++                              4             94             25            407
-Markdown                         1             23              0             65
-C/C++ Header                     1             24             31             61
-make                             2             20              3             32
--------------------------------------------------------------------------------
-SUM:                             8            161             59            565
--------------------------------------------------------------------------------
-Saving session...
-...saving history...truncating history files...
-...completed.
-     278 text files.
-     278 unique files.                                          
-       1 file ignored.
-
-github.com/AlDanial/cloc v 1.68  T=0.12 s (2377.4 files/s, 58619.0 lines/s)
--------------------------------------------------------------------------------
-Language                     files          blank        comment           code
--------------------------------------------------------------------------------
-JSON                           269              0              0           5884
-C                                3             58             20            431
-Python                           1             25             13            146
-Lua                              2             21              0             79
-Markdown                         1             31              0             44
-make                             1             17             24             37
--------------------------------------------------------------------------------
-SUM:                           277            152             57           6621
--------------------------------------------------------------------------------
-Saving session...
-...saving history...truncating history files...
-...completed.
-Saving session...
-...saving history...truncating history files...
-...completed.
--bash: cd: ./*/: No such file or directory
-Saving session...
-...saving history...truncating history files...
-...completed.
--bash: cd: ./*/: No such file or directory
-Saving session...
-...saving history...truncating history files...
-...completed.
-      14 text files.
-      14 unique files.                              
-       4 files ignored.
-
-github.com/AlDanial/cloc v 1.68  T=0.01 s (724.3 files/s, 21800.4 lines/s)
--------------------------------------------------------------------------------
-Language                     files          blank        comment           code
--------------------------------------------------------------------------------
-Scala                            9             56              1            209
-Markdown                         1             14              0             21
--------------------------------------------------------------------------------
-SUM:                            10             70              1            230
--------------------------------------------------------------------------------
-Saving session...
-...saving history...truncating history files...
-...completed.
-      57 text files.
-      57 unique files.                              
-      14 files ignored.
-
-github.com/AlDanial/cloc v 1.68  T=0.07 s (644.5 files/s, 84766.0 lines/s)
--------------------------------------------------------------------------------
-Language                     files          blank        comment           code
--------------------------------------------------------------------------------
-Scala                           31            998            467           4124
-XML                              6              4             15            178
-Bourne Shell                     6             27              5            130
-HTML                             2             13              0             66
-YAML                             1              0              0             23
--------------------------------------------------------------------------------
-SUM:                            46           1042            487           4521
--------------------------------------------------------------------------------
-Saving session...
-...saving history...truncating history files...
-...completed.
-Saving session...
-...saving history...truncating history files...
-...completed.
-</pre>
 **an archive**
 
 We'll pull cloc's source zip file from GitHub, then count the contents:


### PR DESCRIPTION
If you need any clarification for this contribution I can be reached at email.
MichaelDimmitt@icloud.com
a more in depth description/ example can be found here:
https://github.com/MichaelDimmitt/Bash_Directory_CLOC-Count-Lines-of-Program

program will work appropriately if too much nesting is performed.
However, will miss submost levels if nesting does not exist to reach that level.
each time you nest the command, you access a level deeper into a directory.

This command that I am adding was very useful when I was evaluating a large number of projects on github.
I would put them in a repository. Clone the repository down. And run the allSubdir's command to quickly see how large the different programs were before looking at any of the code.

nice overall program, cheers! Michael Dimmitt