### PR TITLE
Document idiosyncrazy of --strip-comments

### DIFF
--- a/Unix/cloc
+++ b/Unix/cloc
@@ -308,10 +308,11 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              receive source code via STDIN.)
    --strip-comments=<ext>    For each file processed, write to the current
                              directory a version of the file which has blank
-                             lines and comments removed.  The name of each
-                             stripped file is the original file name with
-                             .<ext> appended to it.  It is written to the
-                             current directory unless --original-dir is on.
+                             and commented lines removed (in-line comments
+                             persist).  The name of each stripped file is the 
+                             original file name with .<ext> appended to it.  
+                             It is written to the current directory unless 
+                             --original-dir is on.
    --sum-reports             Input arguments are report files previously
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the

--- a/Unix/cloc.1.pod
+++ b/Unix/cloc.1.pod
@@ -276,9 +276,10 @@ Count lines streamed via I<STDIN> as if they came from a file named FILE.
 =item B<--strip-comments=EXT>
 
 For each file processed, write to the current directory a version of
-the file which has blank lines and comments removed. The name of each
-stripped file is the original file name with C<.EXT> appended to it.
-It is written to the current directory unless B<--original-dir> is on.
+the file which has blank and commented lines removed (in-line comments
+persist). The name of each stripped file is the original file name with 
+C<.EXT> appended to it. It is written to the current directory unless 
+B<--original-dir> is on.
 
 =item B<--original-dir>
 

--- a/cloc
+++ b/cloc
@@ -310,10 +310,11 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              receive source code via STDIN.)
    --strip-comments=<ext>    For each file processed, write to the current
                              directory a version of the file which has blank
-                             lines and comments removed.  The name of each
-                             stripped file is the original file name with
-                             .<ext> appended to it.  It is written to the
-                             current directory unless --original-dir is on.
+                             and commented lines removed (in-line comments
+                             persist).  The name of each stripped file is the 
+                             original file name with .<ext> appended to it.  
+                             It is written to the current directory unless 
+                             --original-dir is on.
    --sum-reports             Input arguments are report files previously
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the


### PR DESCRIPTION
Adds documentation for the fact that in-line comments are not
removed by --strip--comments.

Refs #153