### PR TITLE
A Python wrapper that can generate text report file.

### DIFF
--- a/cloc
+++ b/cloc
@@ -128,6 +128,7 @@ if ($ON_WINDOWS and $ENV{'SHELL'}) {
         $ON_WINDOWS = 1;  # MKS defines $SHELL but still acts like Windows
     }
 }
+my $HAVE_SLOCCOUNT_c_count = external_utility_exists("echo 'abc' | c_count");
 
 my $NN     = chr(27) . "[0m";  # normal
    $NN     = "" if $ON_WINDOWS or !(-t STDERR); # -t STDERR:  is it a terminal?
@@ -1694,11 +1695,20 @@ foreach my $file (sort keys %unique_source_file) {
         next;
     }
 
-    my ($all_line_count,
-        $blank_count   ,
-        $comment_count ,
-       ) = call_counter($file, $Language{$file}, \@Errors);
-    my $code_count = $all_line_count - $blank_count - $comment_count;
+    my ($all_line_count, $blank_count, $comment_count, $code_count);
+    if ($HAVE_SLOCCOUNT_c_count and ($Language{$file} eq 'C' or
+                                     $Language{$file} eq 'C++')) {
+        $code_count = `cat $file | c_count | head -n 1`;
+        $code_count = substr($code_count, 0, -2);
+        chomp ($blank_count     = `grep -Pcv '\\S' $file`);
+        chomp ($all_line_count  = `cat $file | wc -l`);
+        $comment_count = $all_line_count - $code_count - $blank_count;
+    } else {
+        ($all_line_count,
+         $blank_count   ,
+         $comment_count ,) = call_counter($file, $Language{$file}, \@Errors);
+        $code_count = $all_line_count - $blank_count - $comment_count;
+    }
     if ($opt_by_file) {
         $Results_by_File{$file}{'code'   } = $code_count     ;
         $Results_by_File{$file}{'blank'  } = $blank_count    ;

--- a/cloc
+++ b/cloc
@@ -305,12 +305,11 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              executables c_count, java_count, pascal_count,
                              php_count, and xml_count instead of cloc's
                              counters.  SLOCCount's compiled counters are
-                             substantially faster than cloc's and give
-                             a noticable performance improvement when
-                             counting projects with large files.  However,
-                             these cloc-specific features will not be available:
-                             --diff, --count-and-diff, --strip-comments,
-                             --unicode.
+                             substantially faster than cloc's and may give
+                             a performance improvement when counting projects
+                             with large files.  However, these cloc-specific
+                             features will not be available: --diff,
+                             --count-and-diff, --strip-comments, --unicode.
    --windows                 Override the operating system autodetection
                              logic and run in Microsoft Windows mode.
                              See also --unix, --show-os.

--- a/cloc
+++ b/cloc
@@ -1836,7 +1836,10 @@ sub combine_results {                        # {{{1
                    )?
                    $}x) {
                 if ($report_type eq "by language") {
-                    next unless @{$rhaa_Filters_by_Language->{$1}};
+                    if (!defined $rhaa_Filters_by_Language->{$1}) {
+                        warn "Unrecognized language '$1' in $file ignored\n";
+                        next;
+                    }
                     # above test necessary to avoid trying to sum reports
                     # of reports (which have no language breakdown).
                     $found_language = 1;

--- a/cloc
+++ b/cloc
@@ -254,6 +254,9 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              than 2 GB of memory will cause problems.
                              Note:  this check does not apply to files
                              explicitly passed as command line arguments.
+   --original-dir            [Only effective in combination with
+                             --strip-comments]  Write the stripped files
+                             to the same directory as the original files.
    --read-binary-files       Process binary files in addition to text files.
                              This is usually a bad idea and should only be
                              attempted with text files that have embedded
@@ -291,9 +294,6 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              stripped file is the original file name with
                              .<ext> appended to it.  It is written to the
                              current directory unless --original-dir is on.
-   --original-dir            [Only effective in combination with
-                             --strip-comments]  Write the stripped files
-                             to the same directory as the original files.
    --sum-reports             Input arguments are report files previously
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the
@@ -301,6 +301,16 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.
+   --use-sloccount           If SLOCCount is installed, use its compiled
+                             executables c_count, java_count, pascal_count,
+                             php_count, and xml_count instead of cloc's
+                             counters.  SLOCCount's compiled counters are
+                             substantially faster than cloc's and give
+                             a noticable performance improvement when
+                             counting projects with large files.  However,
+                             these cloc-specific features will not be available:
+                             --diff, --count-and-diff, --strip-comments,
+                             --unicode.
    --windows                 Override the operating system autodetection
                              logic and run in Microsoft Windows mode.
                              See also --unix, --show-os.
@@ -537,6 +547,7 @@ my (
     $opt_show_os              ,
     $opt_skip_archive         ,
     $opt_max_file_size        ,   # in MB
+    $opt_use_sloccount        ,
    );
 my $getopt_success = GetOptions(
    "by_file|by-file"                         => \$opt_by_file             ,
@@ -614,6 +625,7 @@ my $getopt_success = GetOptions(
    "show_os|show-os"                         => \$opt_show_os             ,
    "skip_archive|skip-archive=s"             => \$opt_skip_archive        ,
    "max_file_size|max-file-size=i"           => \$opt_max_file_size       ,
+   "use_sloccount|use-sloccount"             => \$opt_use_sloccount       ,
   );
 $opt_by_file  = 1 if defined  $opt_by_file_by_lang;
 my $CLOC_XSL = "cloc.xsl"; # created with --xsl
@@ -650,6 +662,22 @@ $opt_csv               = 1  if $opt_csv_delimiter;
 $ON_WINDOWS            = 1  if $opt_force_on_windows;
 $ON_WINDOWS            = 0  if $opt_force_on_unix;
 $opt_max_file_size     = 100 unless $opt_max_file_size;
+if ($opt_use_sloccount) {
+    if (!$HAVE_SLOCCOUNT_c_count) {
+        warn "c_count could not be found; ignoring --use-sloccount\n";
+        $opt_use_sloccount = 0;
+    } else {
+        warn "Using c_count, php_count, xml_count, pascal_count from SLOCCount\n";
+        warn "--diff is disabled with --use-sloccount\n" if $opt_diff;
+        warn "--count-and-diff is disabled with --use-sloccount\n" if $opt_count_diff;
+        warn "--unicode is disabled with --use-sloccount\n" if $opt_unicode;
+        warn "--strip-comments is disabled with --use-sloccount\n" if $opt_strip_comments;
+        $opt_diff           = 0;
+        $opt_count_diff     = undef;
+        $opt_unicode        = 0;
+        $opt_strip_comments = 0;
+    }
+}
 
 my @COUNT_DIFF_ARGV        = undef;
 my $COUNT_DIFF_report_file = undef;
@@ -1696,12 +1724,23 @@ foreach my $file (sort keys %unique_source_file) {
     }
 
     my ($all_line_count, $blank_count, $comment_count, $code_count);
-    if ($HAVE_SLOCCOUNT_c_count and ($Language{$file} eq 'C' or
-                                     $Language{$file} eq 'C++')) {
-        $code_count = `cat $file | c_count | head -n 1`;
-        $code_count = substr($code_count, 0, -2);
+    if ($opt_use_sloccount and $Language{$file} =~ /^(C|C\+\+|XML|PHP|Pascal|Java)$/) {
         chomp ($blank_count     = `grep -Pcv '\\S' $file`);
         chomp ($all_line_count  = `cat $file | wc -l`);
+        if      ($Language{$file} =~ /^(C|C\+\+)$/) {
+            $code_count = `cat $file | c_count | head -n 1`;
+        } elsif ($Language{$file} eq "XML") {
+            $code_count = `cat $file | xml_count | head -n 1`;
+        } elsif ($Language{$file} eq "PHP") {
+            $code_count = `cat $file | php_count | head -n 1`;
+        } elsif ($Language{$file} eq "Pascal") {
+            $code_count = `cat $file | pascal_count | head -n 1`;
+        } elsif ($Language{$file} eq "Java") {
+            $code_count = `cat $file | java_count | head -n 1`;
+        } else {
+            die "SLOCCount match failure: file=[$file] lang=[$Language{$file}]";
+        }
+        $code_count = substr($code_count, 0, -2);
         $comment_count = $all_line_count - $code_count - $blank_count;
     } else {
         ($all_line_count,
@@ -2526,8 +2565,12 @@ sub generate_sql    {                        # {{{1
        ) = @_;
     print "-> generate_sql\n" if $opt_v > 2;
 
+if (defined $opt_sql_project) { print "defined\n"; } else { print "not defined\n"; }
+#print "generate_sql A [$opt_sql_project]\n";
     $opt_sql_project = cwd() unless defined $opt_sql_project;
+#print "generate_sql B [$opt_sql_project]\n";
     $opt_sql_project =~ s{/}{\\}g if $ON_WINDOWS;
+#print "generate_sql C [$opt_sql_project]\n";
 
     my $schema = undef;
     if ($opt_sql_style eq "oracle") {

--- a/cloc
+++ b/cloc
@@ -4004,6 +4004,12 @@ sub classify_file {                          # {{{1
                 }
             } elsif ($Language_by_Extension{$extension} eq 'TypeScript/Qt Linguist') {
                 return TypeScript_or_QtLinguist( $full_file, $rh_Err, $raa_errors);
+            } elsif ($Language_by_Extension{$extension} eq 'Brainfuck') {
+                if (really_is_bf($full_file)) {
+                    return $Language_by_Extension{$extension};
+                } else {
+                    return $language; # (unknown)
+                }
             } else {
                 return $Language_by_Extension{$extension};
             }
@@ -4862,6 +4868,30 @@ sub remove_bf_comments {                     # {{{1
 
     print "<- remove_bf_comments\n" if $opt_v > 2;
     return @save_lines;
+} # 1}}}
+sub really_is_bf {                           # {{{1
+    my ($file, ) = @_;
+
+    print "-> really_is_bf\n" if $opt_v > 2;
+    my $n_bf_indicators  = 0;
+    my @lines = read_file($file);
+    foreach my $L (@lines) {
+        my $ind = 0;
+        if ($L =~ /([+-]{4,}  |          # at least four +'s or -'s in a row
+                   [\[\]]{4,} |          # at least four [ or ] in a row
+                   [<>][+-]   |          # >- or >+ or <+ or <-
+                   <{3,}      |          # at least three < in a row
+                   ^\s*[\[\]]\s*$)/x) {  # [ or ] on line by itself
+            ++$n_bf_indicators;
+            $ind = 1;
+        }
+        # if ($ind) { print "YES: $L"; } else { print "NO : $L"; }
+    }
+    my $ratio = $n_bf_indicators/scalar(@lines);
+    my $decision = ($ratio > 0.5) || ($n_bf_indicators > 5);
+    printf "<- really_is_bf(Y/N=%d %s, R=%.3f, N=%d)\n",
+            $decision, $file, $ratio, $n_bf_indicators if $opt_v > 2;
+    return $decision;
 } # 1}}}
 sub remove_intented_block {                  # {{{1
     # Haml block comments are defined by a silent comment marker like

--- a/cloc
+++ b/cloc
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # cloc -- Count Lines of Code                  {{{1
-# Copyright (C) 2006-2015 Al Danial <al.danial@gmail.com>
+# Copyright (C) 2006-2016 Al Danial <al.danial@gmail.com>
 # First release August 2006
 #
 # Includes code from:
@@ -29,8 +29,8 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "1.65";  # odd number == beta; even number == stable
-my $URL     = "https://github.com/AlDanial/cloc";
+my $VERSION = "1.67";  # odd number == beta; even number == stable
+my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.006;
 # use modules                                  {{{1
 use warnings;
@@ -80,6 +80,7 @@ if (defined $Algorithm::Diff::VERSION) {
 }
 # print "2 HAVE_Algorith_Diff = $HAVE_Algorith_Diff\n";
 # test_alg_diff($ARGV[$#ARGV - 1], $ARGV[$#ARGV]); die;
+# die "Hre=$HAVE_Rexexp_Common  Had=$HAVE_Algorith_Diff";
 
 # Uncomment next two lines when building Windows executable with perl2exe
 # or if running on a system that already has Regexp::Common.
@@ -163,9 +164,26 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              relative path names will be resolved starting from
                              the directory where cloc is invoked.
                              See also --exclude-list-file.
+   --vcs=<VCS>               Invoke a system call to <VCS> to obtain a list of
+                             files to work on.  If <VCS> is 'git', then will
+                             invoke 'git ls-files'.  If <VCS> is 'svn' then
+                             will invoke 'svn list -R'.  The primary benefit
+                             is that cloc will then skip files explicitly
+                             excluded by the versioning tool in question,
+                             ie, those in .gitignore or have the svn:ignore
+                             property.
+                             Alternatively <VCS> may be any system command
+                             that generates a list of files.
+                             Note:  cloc must be in a directory which can read
+                             the files as they are returned by <VCS>.  cloc will
+                             not download files from remote repositories.
+                             'svn list -R' may refer to a remote repository
+                             to obtain file names (and therefore may require
+                             authentication to the remote repository), but
+                             the files themselves must be local.
    --unicode                 Check binary files to see if they contain Unicode
                              expanded ASCII text.  This causes performance to
-                             drop noticably.
+                             drop noticeably.
 
  ${BB}Processing Options${NN}
    --autoconf                Count .in files (as processed by GNU autoconf) of
@@ -209,12 +227,12 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              then use these filters instead of the built-in
                              filters.  Note:  languages which map to the same
                              file extension (for example:
-                             MATLAB/Objective C/MUMPS/Mercury;  Pascal/PHP;
-                             Lisp/OpenCL; Lisp/Julia; Perl/Prolog) will be
-                             ignored as these require additional processing
-                             that is not expressed in language definition
-                             files.  Use --read-lang-def to define new
-                             language filters without replacing built-in
+                             MATLAB/Mathematica/Objective C/MUMPS/Mercury;
+                             Pascal/PHP; Lisp/OpenCL; Lisp/Julia; Perl/Prolog)
+                             will be ignored as these require additional
+                             processing that is not expressed in language
+                             definition files.  Use --read-lang-def to define
+                             new language filters without replacing built-in
                              filters (see also --write-lang-def).
    --ignore-whitespace       Ignore horizontal white space when comparing files
                              with --diff.  See also --ignore-case.
@@ -290,10 +308,14 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
    --exclude-dir=<D1>[,D2,]  Exclude the given comma separated directories
                              D1, D2, D3, et cetera, from being scanned.  For
                              example  --exclude-dir=.cache,test  will skip
-                             all files that have /.cache/ or /test/ as part
-                             of their path.
+                             all files and subdirectories that have /.cache/ 
+                             or /test/ as their parent directory.
                              Directories named .bzr, .cvs, .hg, .git, and
                              .svn are always excluded.
+                             This option only works with individual directory
+                             names so including file path separators is not
+                             allowed.  Use --fullpath and --not-match-d=<regex>
+                             to supply a regex matching multiple subdirectories.
    --exclude-ext=<ext1>[,<ext2>[...]]
                              Do not count files having the given file name
                              extensions.
@@ -305,21 +327,30 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
                              relative path names will be resolved starting from
                              the directory where cloc is invoked.
                              See also --list-file.
-   --fullpath                Modifies the behavior of --match-f or
-                             --not-match-f to include the file's path
+   --fullpath                Modifies the behavior of --match-f, --not-match-f,
+                             and --not-match-d to include the file's path
                              in the regex, not just the file's basename.
                              (This does not expand each file to include its
                              absolute path, instead it uses as much of
                              the path as is passed in to cloc.)
+                             Note:  --match-d always looks at the full
+                             path and therefore is unaffected by --fullpath.
    --include-lang=<L1>[,L2,] Count only the given comma separated languages
                              L1, L2, L3, et cetera.
    --match-d=<regex>         Only count files in directories matching the Perl
                              regex.  For example
                                --match-d='/(src|include)/'
                              only counts files in directories containing
-                             /src/ or /include/.
+                             /src/ or /include/.  Unlike --not-match-d,
+                             --match-f, and --not-match-f, --match-d always
+                             compares the fully qualified path against the regex.
    --not-match-d=<regex>     Count all files except those in directories
-                             matching the Perl regex.
+                             matching the Perl regex.  Only the trailing
+                             directory name is compared, for example, when
+                             counting in /usr/local/lib, only 'lib' is
+                             compared to the regex.
+                             Add --fullpath to compare parent directories to 
+                             the regex.
    --match-f=<regex>         Only count files whose basenames match the Perl
                              regex.  For example
                                --match-f='^[Ww]idget'
@@ -341,15 +372,15 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
  ${BB}Debug Options${NN}
    --categorized=<file>      Save names of categorized files to <file>.
    --counted=<file>          Save names of processed source files to <file>.
+   --diff-alignment=<file>   Write to <file> a list of files and file pairs
+                             showing which files were added, removed, and/or
+                             compared during a run with --diff.  This switch
+                             forces the --diff mode on.
    --explain=<lang>          Print the filters used to remove comments for
                              language <lang> and exit.  In some cases the
                              filters refer to Perl subroutines rather than
                              regular expressions.  An examination of the
                              source code may be needed for further explanation.
-   --diff-alignment=<file>   Write to <file> a list of files and file pairs
-                             showing which files were added, removed, and/or
-                             compared during a run with --diff.  This switch
-                             forces the --diff mode on.
    --help                    Print this usage information and exit.
    --found=<file>            Save names of every file found to <file>.
    --ignored=<file>          Save names of ignored files and the reason they
@@ -389,6 +420,8 @@ Usage: $script [options] <file(s)/dir(s)> | <set 1> <set 2> | <report files>
    --csv                     Write the results as comma separated values.
    --csv-delimiter=<C>       Use the character <C> as the delimiter for comma
                              separated files instead of ,.  This switch forces
+   --json                    Write the results as JavaScript Object Notation
+                             (JSON) formatted output.
    --md                      Write the results as Markdown-formatted text.
    --out=<file>              Synonym for --report-file=<file>.
    --progress-rate=<n>       Show progress update after every <n> files are
@@ -446,6 +479,7 @@ my (
     $opt_progress_rate        ,
     $opt_print_filter_stages  ,
     $opt_v                    ,
+    $opt_vcs                  ,
     $opt_version              ,
     $opt_exclude_lang         ,
     $opt_exclude_list_file    ,
@@ -474,6 +508,7 @@ my (
     $opt_csv                  ,
     $opt_csv_delimiter        ,
     $opt_fullpath             ,
+    $opt_json                 ,
     $opt_md                   ,
     $opt_match_f              ,
     $opt_not_match_f          ,
@@ -539,6 +574,7 @@ my $getopt_success = GetOptions(
    "no3"                                     => \$opt_no3                 ,  # ignored
    "3"                                       => \$opt_3                   ,
    "v|verbose:i"                             => \$opt_v                   ,
+   "vcs=s"                                   => \$opt_vcs                 ,
    "version"                                 => \$opt_version             ,
    "write_lang_def|write-lang-def=s"         => \$opt_write_lang_def      ,
    "xml"                                     => \$opt_xml                 ,
@@ -548,6 +584,7 @@ my $getopt_success = GetOptions(
    "yaml"                                    => \$opt_yaml                ,
    "csv"                                     => \$opt_csv                 ,
    "csv_delimeter|csv-delimiter=s"           => \$opt_csv_delimiter       ,
+   "json"                                    => \$opt_json                ,
    "md"                                      => \$opt_md                  ,
    "fullpath"                                => \$opt_fullpath            ,
    "match_f|match-f=s"                       => \$opt_match_f             ,
@@ -581,13 +618,14 @@ $opt_by_file  = 1 if defined  $opt_by_file_by_lang;
 my $CLOC_XSL = "cloc.xsl"; # created with --xsl
    $CLOC_XSL = "cloc-diff.xsl" if $opt_diff;
 die "\n" unless $getopt_success;
-die $usage if $opt_help;
+print $usage and exit if $opt_help;
 my %Exclude_Language = ();
    %Exclude_Language = map { $_ => 1 } split(/,/, $opt_exclude_lang)
         if $opt_exclude_lang;
 my %Exclude_Dir      = ();
    %Exclude_Dir      = map { $_ => 1 } split(/,/, $opt_exclude_dir )
         if $opt_exclude_dir ;
+die unless exclude_dir_validates(\%Exclude_Dir);
 my %Include_Language = ();
    %Include_Language = map { $_ => 1 } split(/,/, $opt_include_lang)
         if $opt_include_lang;
@@ -626,6 +664,7 @@ if ($opt_count_diff) {
 }
 
 # Options defaults:
+$opt_quiet         =   1 if ($opt_md or $opt_json) and !defined $opt_report_file;
 $opt_progress_rate = 100 unless defined $opt_progress_rate;
 $opt_progress_rate =   0 if     defined $opt_quiet;
 if (!defined $opt_v) {
@@ -663,12 +702,21 @@ if ($opt_by_percent and $opt_by_percent !~ m/^(c|cm|cb|cmb)$/i) {
 }
 $opt_by_percent = lc $opt_by_percent;
 
+if (defined $opt_vcs) {
+    if      ($opt_vcs eq "git") {
+        $opt_vcs = "git ls-files";
+    } elsif ($opt_vcs eq "svn") {
+        $opt_vcs = "svn list -R";
+    }
+}
+
 die $usage unless defined $opt_version         or
                   defined $opt_show_lang       or
                   defined $opt_show_ext        or
                   defined $opt_show_os         or
                   defined $opt_write_lang_def  or
                   defined $opt_list_file       or
+                  defined $opt_vcs             or
                   defined $opt_xsl             or
                   defined $opt_explain         or
                   scalar @ARGV >= 1;
@@ -869,6 +917,9 @@ if ($opt_sum_reports and $opt_diff) {
     if ($opt_list_file) { # read inputs from the list file
         my @list = read_list_file($opt_list_file);
         @results = combine_diffs(\@list);
+    } elsif ($opt_vcs) { # read inputs from the VCS generator
+        my @list = invoke_generator($opt_vcs);
+        @results = combine_diffs(\@list);
     } else { # get inputs from the command line
         @results = combine_diffs(\@ARGV);
     }
@@ -883,8 +934,14 @@ if ($opt_sum_reports) {
     my %Results = ();
     foreach my $type( "by language", "by report file" ) {
         my $found_lang = undef;
-        if ($opt_list_file) { # read inputs from the list file
-            my @list = read_list_file($opt_list_file);
+        if ($opt_list_file or $opt_vcs) {
+            # read inputs from the list file
+            my @list;
+            if ($opt_vcs) {
+                @list = invoke_generator($opt_vcs);
+            } else {
+                @list = read_list_file($opt_list_file);
+            }
             $found_lang = combine_results(\@list,
                                            $type,
                                           \%{$Results{ $type }},
@@ -1551,8 +1608,13 @@ if ($opt_by_file) {
 } else {
 # Step 4:  Separate code from non-code files.  {{{1
 my $fh = 0;
-if ($opt_list_file) {
-    my @list = read_list_file($opt_list_file);
+if ($opt_list_file or $opt_vcs) {
+    my @list;
+    if ($opt_vcs) {
+        @list = invoke_generator($opt_vcs);
+    } else {
+        @list = read_list_file($opt_list_file);
+    }
     $fh = make_file_list(\@list, \%Error_Codes, \@Errors, \%Ignored);
 } else {
     $fh = make_file_list(\@ARGV, \%Error_Codes, \@Errors, \%Ignored);
@@ -1694,6 +1756,20 @@ if ($opt_count_diff) {
     goto Top_of_Processing_Loop;
 }
 
+sub exclude_dir_validates {                  # {{{1
+    my ($rh_Exclude_Dir) = @_;
+    my $is_OK = 1;
+    foreach my $dir (keys %{$rh_Exclude_Dir}) {
+        if (($ON_WINDOWS and $dir =~ m{\\}) or ($dir =~ m{/})) {
+            $is_OK = 0;
+            warn "--exclude-dir '$dir' :  cannot specify directory paths\n";
+        }
+    }
+    if (!$is_OK) {
+        warn "Use '--fullpath --not-match-d=REGEX' instead\n";
+    }
+    return $is_OK;
+} # 1}}}
 sub process_exclude_list_file {              # {{{1
     my ($list_file      , # in
         $rh_exclude_dir , # out
@@ -1822,13 +1898,33 @@ sub compute_denominator {                    # {{{1
     print "<- compute_denominator\n" if $opt_v > 2;
     return $den{ $method };
 } # 1}}}
+sub yaml_to_json_separators {                # {{{1
+    # YAML and JSON are closely related.  Their differences can be captured
+    # by trailing commas ($C), braces ($open_B, $close_B), and
+    # quotes around text ($Q).
+    my ($Q, $open_B, $close_B, $start, $C);
+    if ($opt_json) {
+       $C       = ',';
+       $Q       = '"';
+       $open_B  = '{';
+       $close_B = '}';
+       $start   = '{';
+    } else {
+       $C       = '';
+       $Q       = '' ;
+       $open_B  = '' ;
+       $close_B = '';
+       $start   = "---\n# $URL\n";
+    }
+    return ($Q, $open_B, $close_B, $start, $C);
+} # 1}}}
 sub diff_report     {                        # {{{1
     # returns an array of lines containing the results
     print "-> diff_report\n" if $opt_v > 2;
 
-    if ($opt_xml or $opt_yaml) {
+    if ($opt_xml or $opt_yaml or $opt_json) {
         print "<- diff_report\n" if $opt_v > 2;
-        return diff_xml_yaml_report(@_)
+        return diff_xml_yaml_json_report(@_)
     } elsif ($opt_csv or $opt_md) {
         print "<- diff_report\n" if $opt_v > 2;
         return diff_csv_report(@_)
@@ -1897,6 +1993,7 @@ sub diff_report     {                        # {{{1
     my $Style = "txt";
        $Style = "xml" if $opt_xml ;
        $Style = "xml" if $opt_yaml;  # not a typo; just set to anything but txt
+       $Style = "xml" if $opt_json;  # not a typo; just set to anything but txt
        $Style = "xml" if $opt_csv ;  # not a typo; just set to anything but txt
 
     my $hyphen_line = sprintf "%s", '-' x (79 + $column_1_offset);
@@ -1999,7 +2096,7 @@ sub diff_report     {                        # {{{1
             push @results, $line;
         }
     }
-    push @results, "-" x 79;
+    push @results, $hyphen_line;
     push @results, "SUM:";
     foreach my $S (qw(same modified added removed)) {
         my $indent = $spacing_1 - 2;
@@ -2029,15 +2126,15 @@ sub diff_report     {                        # {{{1
         }
         push @results, $line;
     }
-    push @results, "-" x 79;
+    push @results, $hyphen_line;
     write_xsl_file() if $opt_xsl and $opt_xsl eq $CLOC_XSL;
     print "<- diff_report\n" if $opt_v > 2;
 
     return @results;
 } # 1}}}
-sub xml_or_yaml_header {                     # {{{1
+sub xml_yaml_or_json_header {                # {{{1
     my ($URL, $version, $elapsed_sec, $sum_files, $sum_lines, $by_file) = @_;
-    print "-> xml_or_yaml_header\n" if $opt_v > 2;
+    print "-> xml_yaml_or_json_header\n" if $opt_v > 2;
     my $header      = "";
     my $file_rate   = $sum_files/$elapsed_sec;
     my $line_rate   = $sum_lines/$elapsed_sec;
@@ -2070,32 +2167,33 @@ sub xml_or_yaml_header {                     # {{{1
         $header .= "\n$report_file"
             if $opt_report_file;
         $header .= "\n</header>";
-    } elsif ($opt_yaml) {
-        $header = "---\n# $URL
-header :
-  cloc_url           : http://cloc.sourceforge.net
-  cloc_version       : $version
-  elapsed_seconds    : $elapsed_sec
-  n_files            : $sum_files
-  n_lines            : $sum_lines
-  files_per_second   : $file_rate
-  lines_per_second   : $line_rate";
+    } elsif ($opt_yaml or $opt_json) {
+        my ($Q, $open_B, $close_B, $start, $C) = yaml_to_json_separators();
+        $header = "${start}${Q}header${Q} : $open_B
+  ${Q}cloc_url${Q}           : ${Q}$URL${Q}${C}
+  ${Q}cloc_version${Q}       : ${Q}$version${Q}${C}
+  ${Q}elapsed_seconds${Q}    : $elapsed_sec${C}
+  ${Q}n_files${Q}            : $sum_files${C}
+  ${Q}n_lines${Q}            : $sum_lines${C}
+  ${Q}files_per_second${Q}   : $file_rate${C}
+  ${Q}lines_per_second${Q}   : $line_rate";
         if ($opt_report_file) {
             if ($opt_sum_reports) {
                 if ($by_file) {
-                    $header .= "\n  report_file        : $opt_report_file.file"
+                    $header .= "$C\n  ${Q}report_file${Q}        : ${Q}$opt_report_file.file${Q}"
                 } else {
-                    $header .= "\n  report_file        : $opt_report_file.lang"
+                    $header .= "$C\n  ${Q}report_file${Q}        : ${Q}$opt_report_file.lang${Q}"
                 }
             } else {
-                $header .= "\n  report_file        : $opt_report_file";
+                $header .= "$C\n  ${Q}report_file${Q}        : ${Q}$opt_report_file${Q}";
             }
         }
+        $header .= "${close_B}${C}";
     }
-    print "<- xml_or_yaml_header\n" if $opt_v > 2;
+    print "<- xml_yaml_or_json_header\n" if $opt_v > 2;
     return $header;
 } # 1}}}
-sub diff_xml_yaml_report {                   # {{{1
+sub diff_xml_yaml_json_report {              # {{{1
     # returns an array of lines containing the results
     my ($version    , # in
         $elapsed_sec, # in
@@ -2103,7 +2201,8 @@ sub diff_xml_yaml_report {                   # {{{1
         $rhhh_count , # in  count{TYPE}{nFiles|code|blank|comment}{a|m|r|s}
         $rh_scale   , # in
        ) = @_;
-    print "-> diff_xml_yaml_report\n" if $opt_v > 2;
+    print "-> diff_xml_yaml_json_report\n" if $opt_v > 2;
+    my ($Q, $open_B, $close_B, $start, $C) = yaml_to_json_separators();
 
 #print "diff_report: ", Dumper($rhhh_count), "\n";
     my @results       = ();
@@ -2140,7 +2239,7 @@ sub diff_xml_yaml_report {                   # {{{1
 
     if (!$ALREADY_SHOWED_HEADER) {
         push @results,
-              xml_or_yaml_header($URL, $version, $elapsed_sec,
+              xml_yaml_or_json_header($URL, $version, $elapsed_sec,
                                  $sum_files, $sum_lines, $BY_FILE);
         $ALREADY_SHOWED_HEADER = 1;
     }
@@ -2148,13 +2247,9 @@ sub diff_xml_yaml_report {                   # {{{1
     foreach my $S (qw(same modified added removed)) {
         if ($opt_xml) {
             push @results, "  <$S>";
-        } elsif ($opt_yaml) {
-            push @results, "$S :";
+        } elsif ($opt_yaml or $opt_json) {
+            push @results, "${Q}${S}${Q} : ${open_B}";
         }
-########foreach my $lang_or_file (keys %{$rhhh_count}) {
-########    $rhhh_count->{$lang_or_file}{'code'} = 0 unless
-########        defined $rhhh_count->{$lang_or_file}{'code'};
-########}
         foreach my $lang_or_file (sort {
                                      $rhhh_count->{$b}{'code'} <=>
                                      $rhhh_count->{$a}{'code'}
@@ -2195,14 +2290,14 @@ sub diff_xml_yaml_report {                   # {{{1
                   }
                 }
                 push @results, $L . "/>";
-            } elsif ($opt_yaml) {
+            } elsif ($opt_yaml or $opt_json) {
                 if ($BY_FILE) {
-                    push @results, sprintf "  - file : %s",
+                    push @results, sprintf "    ${Q}file${Q} : ${Q}%s${Q}${C}",
                                    rm_leading_tempdir($lang_or_file, \%TEMP_DIR);
-                    push @results, sprintf "    files_count : 1",
+                    push @results, sprintf "    ${Q}files_count${Q} : 1${C}",
                 } else {
-                    push @results, sprintf "  - language : %s", $lang_or_file;
-                    push @results, sprintf "    files_count : %d",
+                    push @results, sprintf "    ${Q}language${Q} : ${Q}%s${Q}${C}", $lang_or_file;
+                    push @results, sprintf "    ${Q}files_count${Q} : %d${C}",
                             $rhhh_count->{$lang_or_file}{'nFiles'}{$S};
                 }
                 if ($opt_by_percent) {
@@ -2212,19 +2307,19 @@ sub diff_xml_yaml_report {                   # {{{1
                         $rhhh_count->{$lang_or_file}{'blank'}{$S}  );
                     foreach my $T (qw(blank comment)) {
                         if ($rhhh_count->{$lang_or_file}{'code'}{$S} > 0) {
-                            push @results, sprintf "    %s : %.2f",
+                            push @results, sprintf "    ${Q}%s${Q} : %.2f${C}",
                                     $T, $rhhh_count->{$lang_or_file}{$T}{$S} / $DEN * 100;
                         } else {
-                            push @results, sprintf "    %s : 0.0", $T;
+                            push @results, sprintf "    ${Q}%s${Q} : 0.0${C}", $T;
                         }
                     }
                     foreach my $T (qw(code)) {
-                        push @results, sprintf "    %s : %d",
+                        push @results, sprintf "    ${Q}%s${Q} : %d${C}",
                                 $T, $rhhh_count->{$lang_or_file}{$T}{$S};
                     }
                 } else {
                     foreach my $T (qw(blank comment code)) {
-                        push @results, sprintf "    %s : %d",
+                        push @results, sprintf "    ${Q}%s${Q} : %d${C}",
                                 $T, $rhhh_count->{$lang_or_file}{$T}{$S};
                     }
                 }
@@ -2279,13 +2374,15 @@ sub diff_xml_yaml_report {                   # {{{1
                 }
             }
         }
+        $results[-1] =~ s/,\s*$/},/;   # close last set with  },  instead of ,
     }
+    $results[-1] =~ s/,\s*$/}/;   # close last set with  }  instead of ,
 
     if ($opt_xml) {
         push @results, "</diff_results>";
     }
     write_xsl_file() if $opt_xsl and $opt_xsl eq $CLOC_XSL;
-    print "<- diff_xml_yaml_report\n" if $opt_v > 2;
+    print "<- diff_xml_yaml_json_report\n" if $opt_v > 2;
     return @results;
 } # 1}}}
 sub diff_csv_report {                        # {{{1
@@ -2642,6 +2739,7 @@ sub generate_report {                        # {{{1
     my $Style = "txt";
        $Style = "xml" if $opt_xml ;
        $Style = "xml" if $opt_yaml;  # not a typo; just set to anything but txt
+       $Style = "xml" if $opt_json;  # not a typo; just set to anything but txt
        $Style = "xml" if $opt_csv ;  # not a typo; just set to anything but txt
 
     my $hyphen_line = sprintf "%s", '-' x (79 + $column_1_offset);
@@ -2668,10 +2766,10 @@ sub generate_report {                        # {{{1
                         $elapsed_sec           ,
                         $sum_files/$elapsed_sec,
                         $sum_lines/$elapsed_sec) unless $opt_sum_reports;
-    if ($opt_xml or $opt_yaml) {
+    if ($opt_xml or $opt_yaml or $opt_json) {
         if (!$ALREADY_SHOWED_HEADER) {
-            push @results, xml_or_yaml_header($URL, $version, $elapsed_sec,
-                                              $sum_files, $sum_lines, $BY_FILE);
+            push @results, xml_yaml_or_json_header($URL, $version, $elapsed_sec,
+                                                   $sum_files, $sum_lines, $BY_FILE);
             $ALREADY_SHOWED_HEADER = 1 unless $opt_sum_reports;
             # --sum-reports yields two xml or yaml files, one by
             # language and one by report file, each of which needs a header
@@ -2711,7 +2809,7 @@ sub generate_report {                        # {{{1
             "3rd gen. equiv"
               if $opt_3;
         if ($opt_md) {
-            my @col_header  = ();
+            my @col_header  = (); 
             if ($data_line =~ m{\s%}) {
                 $data_line =~ s{\s%}{_%}g;
                 foreach my $w ( split(' ', $data_line) ) {
@@ -2719,7 +2817,7 @@ sub generate_report {                        # {{{1
                     push @col_header, $w;
                 }
             } else {
-                @col_header = split(' ', $data_line);
+                push @col_header, split(' ', $data_line);
             }
             my @col_hyphens    = ( '-------:') x scalar(@col_header);
                $col_hyphens[0] =   ':-------'; # first column left justified
@@ -2730,6 +2828,7 @@ sub generate_report {                        # {{{1
             push @results, $hyphen_line;
         }
     }
+
     if ($opt_csv)  {
         my $header2;
         if ($BY_FILE) {
@@ -2829,30 +2928,34 @@ sub generate_report {                        # {{{1
             } else {
                 push @results, "  <language " . $data_line . "/>";
             }
-        } elsif ($opt_yaml) {
-            push @results,$lang_or_file . ":";
-            push @results,"  nFiles: "  .$rhh_count->{$lang_or_file}{'nFiles'}
+        } elsif ($opt_yaml or $opt_json) {
+            my ($Q, $open_B, $close_B, $start, $C) = yaml_to_json_separators();
+            push @results,"${Q}$lang_or_file${Q} :$open_B";
+            push @results,"  ${Q}nFiles${Q}: " . $rhh_count->{$lang_or_file}{'nFiles'} . $C
                 unless $BY_FILE;
             if ($opt_by_percent) {
               my $DEN = compute_denominator($opt_by_percent       ,
                             $rhh_count->{$lang_or_file}{'code'}   ,
                             $rhh_count->{$lang_or_file}{'comment'},
                             $rhh_count->{$lang_or_file}{'blank'}  );
-              push @results,"  blank_pct: "   .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'blank'} / $DEN * 100);
-              push @results,"  comment_pct: " .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'comment'} / $DEN * 100);
-              push @results,"  code: "    . $rhh_count->{$lang_or_file}{'code'}   ;
+              push @results,"  ${Q}blank_pct${Q}: "   .
+                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'blank'} / $DEN * 100) . $C;
+              push @results,"  ${Q}comment_pct${Q}: " .
+                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'comment'} / $DEN * 100) . $C;
+              push @results,"  ${Q}code${Q}: "    . $rhh_count->{$lang_or_file}{'code'}  . $C;
             } else {
-              push @results,"  blank: "   . $rhh_count->{$lang_or_file}{'blank'}  ;
-              push @results,"  comment: " . $rhh_count->{$lang_or_file}{'comment'};
-              push @results,"  code: "    . $rhh_count->{$lang_or_file}{'code'}   ;
+              push @results,"  ${Q}blank${Q}: "   . $rhh_count->{$lang_or_file}{'blank'}   . $C;
+              push @results,"  ${Q}comment${Q}: " . $rhh_count->{$lang_or_file}{'comment'} . $C;
+              push @results,"  ${Q}code${Q}: "    . $rhh_count->{$lang_or_file}{'code'}    . $C;
             }
-            push @results,"  language: ".$rhh_count->{$lang_or_file}{'lang'}
+            push @results,"  ${Q}language${Q}: "  . $Q . $rhh_count->{$lang_or_file}{'lang'} . $Q . $C
                 if $BY_FILE;
             if ($opt_3) {
-                push @results, "  scaled: " . $scaled;
-                push @results, "  factor: " . $factor;
+                push @results, "  ${Q}scaled${Q}: " . $scaled . $C;
+                push @results, "  ${Q}factor${Q}: " . $factor . $C;
+            }
+            if ($opt_json) { # replace the trailing comma with }, on the last line
+                $results[-1] =~ s/,\s*$/},/;
             }
         } elsif ($opt_csv or $opt_md) {
             my $extra_3 = "";
@@ -2942,25 +3045,29 @@ sub generate_report {                        # {{{1
         } else {
             $ALREADY_SHOWED_XML_SECTION = 1;
         }
-    } elsif ($opt_yaml) {
-        push @results, "SUM:";
+    } elsif ($opt_yaml or $opt_json) {
+        my ($Q, $open_B, $close_B, $start, $C) = yaml_to_json_separators();
+        push @results, "${Q}SUM${Q}: ${open_B}";
         if ($opt_by_percent) {
           my $DEN = compute_denominator($opt_by_percent    ,
                         $sum_code, $sum_comment, $sum_blank);
-          push @results, "  blank: "  . sprintf("%.2f", $sum_blank   / $DEN * 100);
-          push @results, "  comment: ". sprintf("%.2f", $sum_comment / $DEN * 100);
-          push @results, "  code: "   . $sum_code   ;
+          push @results, "  ${Q}blank${Q}: "  . sprintf("%.2f", $sum_blank   / $DEN * 100) . $C;
+          push @results, "  ${Q}comment${Q}: ". sprintf("%.2f", $sum_comment / $DEN * 100) . $C;
+          push @results, "  ${Q}code${Q}: "   . $sum_code    . $C;
         } else {
-          push @results, "  blank: "  . $sum_blank  ;
-          push @results, "  comment: ". $sum_comment;
-          push @results, "  code: "   . $sum_code   ;
+          push @results, "  ${Q}blank${Q}: "  . $sum_blank   . $C;
+          push @results, "  ${Q}comment${Q}: ". $sum_comment . $C;
+          push @results, "  ${Q}code${Q}: "   . $sum_code    . $C;
         }
-        push @results, "  nFiles: " . $sum_files  ;
+        push @results, "  ${Q}nFiles${Q}: " . $sum_files   . $C;
         if ($opt_3) {
-            push @results, "  scaled: " . $sum_scaled;
-            push @results, "  factor: " . $avg_scale ;
+            push @results, "  ${Q}scaled${Q}: " . $sum_scaled . $C;
+            push @results, "  ${Q}factor${Q}: " . $avg_scale  . $C;
         }
-    } elsif ($opt_csv or $opt_md) {
+        if ($opt_json) {
+            $results[-1] =~ s/,\s*$/} }/;
+        }
+    } elsif ($opt_csv) {
         # do nothing
     } else {
 
@@ -2986,9 +3093,20 @@ sub generate_report {                        # {{{1
         $data_line .= sprintf $Format{'6'}{$Style},
             $avg_scale   ,
             $sum_scaled if $opt_3;
-        push @results, $hyphen_line if $sum_files > 1 or $opt_sum_one;
-        push @results, $data_line   if $sum_files > 1 or $opt_sum_one;
-        push @results, $hyphen_line;
+        if ($opt_md) {
+            my @words = split(' ', $data_line);
+            my $n_cols = scalar(@words);
+#           my $n_cols = scalar(split(' ', $data_line));  # deprecated
+            $data_line =~ s/\s+/\|/g;
+            my @col_hyphens    = ( '--------') x $n_cols;
+            push @results, join("|", @col_hyphens);
+            push @results, $data_line   if $sum_files > 1 or $opt_sum_one;
+            unshift @results, ( "cloc|$header_line", "--- | ---", "", );
+        } else {
+            push @results, $hyphen_line if $sum_files > 1 or $opt_sum_one;
+            push @results, $data_line   if $sum_files > 1 or $opt_sum_one;
+            push @results, $hyphen_line;
+        }
     }
     write_xsl_file() if $opt_xsl and $opt_xsl eq $CLOC_XSL;
     print "<- generate_report\n" if $opt_v > 2;
@@ -3028,7 +3146,8 @@ sub write_lang_def {                         # {{{1
     die "Unable to write to $file\n" unless defined $OUT;
 
     foreach my $language (sort keys %{$rhaa_Filters_by_Language}) {
-        next if $language eq "MATLAB/Objective C/MUMPS/Mercury" or
+        next if $language =~ /Brain/;
+        next if $language eq "MATLAB/Mathematica/Objective C/MUMPS/Mercury" or
                 $language eq "PHP/Pascal"                       or
                 $language eq "Pascal/Puppet"                    or
                 $language eq "Lisp/OpenCL"                      or
@@ -3039,6 +3158,7 @@ sub write_lang_def {                         # {{{1
                 $language eq "Fortran 77/Forth"                 or
                 $language eq "F#/Forth"                         or
                 $language eq "Verilog-SystemVerilog/Coq"        or
+                $language eq "TypeScript/Qt Linguist"           or
                 $language eq "(unknown)";
         printf $OUT "%s\n", $language;
         foreach my $filter (@{$rhaa_Filters_by_Language->{$language}}) {
@@ -3224,11 +3344,13 @@ sub print_extension_info {                   # {{{1
     if ($extension) {  # show information on this extension
         foreach my $ext (sort {lc $a cmp lc $b } keys %Language_by_Extension) {
             # Language_by_Extension{f}    = 'Fortran 77'
+            next if $Language_by_Extension{$ext} =~ /Brain/;
             printf "%-15s -> %s\n", $ext, $Language_by_Extension{$ext}
                 if $ext =~ m{$extension}i;
         }
     } else {           # show information on all  extensions
         foreach my $ext (sort {lc $a cmp lc $b } keys %Language_by_Extension) {
+            next if $Language_by_Extension{$ext} =~ /Brain/;
             # Language_by_Extension{f}    = 'Fortran 77'
             printf "%-15s -> %s\n", $ext, $Language_by_Extension{$ext};
         }
@@ -3253,11 +3375,12 @@ sub print_language_info {                    # {{{1
     }
 
     # add exceptions (one file extension mapping to multiple languages)
-    if (!$language or $language =~ /^(Objective C|MATLAB|MUMPS|Mercury)$/i) {
+    if (!$language or $language =~ /^(Objective C|MATLAB|Mathematica|MUMPS|Mercury)$/i) {
         push @{$extensions{'Objective C'}}, "m";
         push @{$extensions{'MATLAB'}}     , "m";
+        push @{$extensions{'Mathematica'}}, "m";
         push @{$extensions{'MUMPS'}}      , "m";
-        delete $extensions{'MATLAB/Objective C/MUMPS/Mercury'};
+        delete $extensions{'MATLAB/Mathematica/Objective C/MUMPS/Mercury'};
     }
     if (!$language or $language =~ /^(Lisp|OpenCL)$/i) {
         push @{$extensions{'Lisp'}}  , "cl";
@@ -3307,6 +3430,11 @@ sub print_language_info {                    # {{{1
         push @{$extensions{'Verilog-SystemVerilog'}} , "v";
         delete $extensions{'Verilog-SystemVerilog/Coq'};
     }
+    if (!$language or $language =~ /^(TypeScript|Qt Linguist)$/) {
+        push @{$extensions{'TypeScript'}}  , "ts";
+        push @{$extensions{'Qt Linguist'}} , "ts";
+        delete $extensions{'TypeScript/Qt Linguist'};
+    }
     if (!$language or $language =~ /^(Ant)$/i) {
         push @{$extensions{'Ant'}}  , "build.xml";
         delete $extensions{'Ant/XML'};
@@ -3321,6 +3449,7 @@ sub print_language_info {                    # {{{1
     } else {
         if (%extensions) {
             foreach my $lang (sort {lc $a cmp lc $b } keys %extensions) {
+                next if $lang =~ /Brain/;
                 if ($prefix) {
                     printf "%s %s\n", $prefix, join(", ", @{$extensions{$lang}});
                 } else {
@@ -3405,9 +3534,28 @@ sub make_file_list {                         # {{{1
             $rh_ignored->{$file_or_dir} = 'not file, not directory';
         }
     }
+
+    # apply exclusion rules to file names passed in on the command line
+    my @new_file_list = ();
+    foreach my $File (@file_list) {
+        my ($volume, $directories, $filename) = File::Spec->splitpath( $File );
+        foreach my $Sub_Dir ( File::Spec->splitdir($directories) ) {
+            if ($Exclude_Dir{$Sub_Dir}) {
+                $Ignored{$Sub_Dir} = "--exclude-dir=$Exclude_Dir{$Sub_Dir}";
+                next;
+            }
+        }
+        push @new_file_list, $File;
+    }
+    @file_list = @new_file_list;
+
     foreach my $dir (@dir_list) {
 #print "make_file_list dir=$dir\n";
         # populates global variable @file_list
+        if ($Exclude_Dir{$dir}) {
+            $Ignored{$dir} = "--exclude-dir=$Exclude_Dir{$dir}";
+            next;
+        }
         find({wanted     => \&files            ,
               preprocess => \&find_preprocessor,
               follow     =>  $opt_follow_links }, $dir);
@@ -3457,6 +3605,21 @@ die  "make_file_list($file) undef lang" unless defined $language;
 
     return $fh;   # handle to the file containing the list of files to process
 }  # 1}}}
+sub invoke_generator {                       # {{{1
+    my ($generator,) = @_;
+    print "-> invoke_generator($generator)\n" if $opt_v > 2;
+    open(FH, "$generator |") or
+        die "Failed to pipe $generator: $!";
+    my @files = ();
+    while(<FH>) {
+        chomp;
+        print "VCS input:  $_\n" if $opt_v >= 2;
+        push @files, $_;
+    }
+    close(FH);
+    print "<- invoke_generator\n" if $opt_v > 2;
+    return @files;
+} # 1}}}
 sub remove_duplicate_files {                 # {{{1
     my ($fh                   , # in
         $rh_Language          , # out
@@ -3531,20 +3694,27 @@ sub find_preprocessor {                      # {{{1
     # Reject files/directories in cwd which are in the exclude list.
 
     my @ok = ();
+
     foreach my $F_or_D (@_) {  # pure file or directory name, no separators
         if ($Exclude_Dir{$F_or_D}) {
             $Ignored{$File::Find::name} = "--exclude-dir=$Exclude_Dir{$F_or_D}";
         } elsif (-d $F_or_D) {
-            if ($opt_not_match_d and $F_or_D =~ m{$opt_not_match_d}) {
-                $Ignored{$File::Find::name} = "--not-match-d=$opt_not_match_d";
+            if ($opt_not_match_d) {
+                if ($opt_fullpath and $File::Find::name =~ m{$opt_not_match_d}) {
+                    $Ignored{$File::Find::name} = "--not-match-d=$opt_not_match_d";
+                } elsif ($F_or_D =~ m{$opt_not_match_d}) {
+                    $Ignored{$File::Find::name} = "--not-match-d (basename) =$opt_not_match_d";
+                } else {
+                    push @ok, $F_or_D;
+                }
             } else {
                 push @ok, $F_or_D;
             }
-
         } else {
             push @ok, $F_or_D;
         }
     }
+
     return @ok;
 } # 1}}}
 sub files {                                  # {{{1
@@ -3616,7 +3786,7 @@ sub is_file {                                # {{{1
 } # 1}}}
 sub is_dir {                                 # {{{1
     # portable method to test if item is a directory
-    # (-d doesn't work in ActiveState Perl on Windows)
+    # (-d doesn't work in older versions of ActiveState Perl on Windows)
     my $item = shift @_;
 
     if ($ON_WINDOWS) {
@@ -3692,7 +3862,7 @@ sub classify_file {                          # {{{1
         }
         if (defined $Language_by_Extension{$extension}) {
             if ($Language_by_Extension{$extension} eq
-                'MATLAB/Objective C/MUMPS/Mercury') {
+                'MATLAB/Mathematica/Objective C/MUMPS/Mercury') {
                 my $lang_M_or_O = "";
                 matlab_or_objective_C($full_file ,
                                       $rh_Err    ,
@@ -3776,6 +3946,8 @@ sub classify_file {                          # {{{1
                 } else {
                     return $language; # (unknown)
                 }
+            } elsif ($Language_by_Extension{$extension} eq 'TypeScript/Qt Linguist') {
+                return TypeScript_or_QtLinguist( $full_file, $rh_Err, $raa_errors);
             } else {
                 return $Language_by_Extension{$extension};
             }
@@ -3820,7 +3992,7 @@ sub classify_file {                          # {{{1
             # returns (unknown)
         }
     }
-    print "<- classify_file($full_file)\n" if $opt_v > 2;
+    print "<- classify_file($full_file)=$language\n" if $opt_v > 2;
     return $language;
 } # 1}}}
 sub peek_at_first_line {                     # {{{1
@@ -4618,16 +4790,33 @@ sub remove_html_comments {                   # {{{1
     print "<- remove_html_comments\n" if $opt_v > 2;
     return @save_lines;
 } # 1}}}
-sub remove_haml_block {                      # {{{1
+sub remove_bf_comments {                     # {{{1
+    my ($ra_lines, ) = @_;
+
+    print "-> remove_bf_comments\n" if $opt_v > 2;
+
+    my @save_lines = ();
+    my $in_comment = 0;
+    foreach (@{$ra_lines}) {
+
+        s/[^<>+-.,\[\]]+//g;
+        next if /^\s*$/;
+        push @save_lines, $_;
+    }
+
+    print "<- remove_bf_comments\n" if $opt_v > 2;
+    return @save_lines;
+} # 1}}}
+sub remove_intented_block {                  # {{{1
     # Haml block comments are defined by a silent comment marker like
     #    /
     # or
     #    -#
     # followed by indented text on subsequent lines.
     # http://haml.info/docs/yardoc/file.REFERENCE.html#comments
-    my ($ra_lines, ) = @_;
+    my ($ra_lines, $regex, ) = @_;
 
-    print "-> remove_haml_block\n" if $opt_v > 2;
+    print "-> remove_intented_block\n" if $opt_v > 2;
 
     my @save_lines = ();
     my $in_comment = 0;
@@ -4646,9 +4835,9 @@ sub remove_haml_block {                      # {{{1
                 # still in comments, don't use this line
                 next;
             }
-        } elsif ($line =~ m{^(\s*)(/|-#)\s*$}) {
+        } elsif ($line =~ m{$regex}) {
             if ($1) {
-                $in_comment = length $1 + 1; # number of leading spaces + 1
+                $in_comment = length($1) + 1; # number of leading spaces + 1
             } else {
                 $in_comment = 1;
             }
@@ -4658,8 +4847,35 @@ sub remove_haml_block {                      # {{{1
         push @save_lines, $line;
     }
 
-    print "<- remove_haml_block\n" if $opt_v > 2;
+    print "<- remove_intented_block\n" if $opt_v > 2;
     return @save_lines;
+} # 1}}}
+sub remove_haml_block {                      # {{{1
+    # Haml block comments are defined by a silent comment marker like
+    #    /
+    # or
+    #    -#
+    # followed by indented text on subsequent lines.
+    # http://haml.info/docs/yardoc/file.REFERENCE.html#comments
+    my ($ra_lines, ) = @_;
+
+    return remove_intented_block($ra_lines, '^(\s*)(/|-#)\s*$');
+
+} # 1}}}
+sub remove_pug_block {                       # {{{1
+    # Haml block comments are defined by a silent comment marker like
+    #    //
+    # followed by indented text on subsequent lines.
+    # http://jade-lang.com/reference/comments/
+    my ($ra_lines, ) = @_;
+    return remove_intented_block($ra_lines, '^(\s*)(//)\s*$');
+} # 1}}}
+sub remove_slim_block {                      # {{{1
+    # slim comments start with /
+    # followed by indented text on subsequent lines.
+    # http://www.rubydoc.info/gems/slim/frames
+    my ($ra_lines, ) = @_;
+    return remove_intented_block($ra_lines, '^(\s*)(/[^!])');
 } # 1}}}
 sub add_newlines {                           # {{{1
     my ($ra_lines, ) = @_;
@@ -4842,7 +5058,10 @@ sub set_constants {                          # {{{1
             'CMD'         => 'DOS Batch'             ,
             'btm'         => 'DOS Batch'             ,
             'BTM'         => 'DOS Batch'             ,
+            'blade.php'   => 'Blade'                 ,
             'build.xml'   => 'Ant'                   ,
+            'b'           => 'Brainfuck'             ,
+            'bf'          => 'Brainfuck'             ,
             'cbl'         => 'COBOL'                 ,
             'CBL'         => 'COBOL'                 ,
             'c'           => 'C'                     ,
@@ -4864,12 +5083,14 @@ sub set_constants {                          # {{{1
             'coffee'      => 'CoffeeScript'          ,
             'component'   => 'Visualforce Component' ,
             'cpp'         => 'C++'                   ,
+            'cr'          => 'Crystal'               ,
             'cs'          => 'C#'                    ,
             'csh'         => 'C Shell'               ,
             'cson'        => 'CSON'                  ,
             'css'         => "CSS"                   ,
             'ctl'         => 'Visual Basic'          ,
             'cu'          => 'CUDA'                  ,
+            'cuh'         => 'CUDA'                  , # CUDA header file
             'cxx'         => 'C++'                   ,
             'd'           => 'D/dtrace'              ,
 # in addition, .d can map to init.d files typically written as
@@ -4924,6 +5145,7 @@ sub set_constants {                          # {{{1
             'fsi'         => 'F#'                    ,
             'gnumakefile' => 'make'                  ,
             'Gnumakefile' => 'make'                  ,
+            'gd'          => 'GDScript'              ,
             'go'          => 'Go'                    ,
             'gsp'         => 'Grails'                ,
             'groovy'      => 'Groovy'                ,
@@ -4961,7 +5183,8 @@ sub set_constants {                          # {{{1
             'jl'          => 'Lisp/Julia'            ,
             'js'          => 'JavaScript'            ,
             'jsf'         => 'JavaServer Faces'      ,
-            'xhtml'       => 'JavaServer Faces'      ,
+            'jsx'         => 'JSX'                   ,
+            'xhtml'       => 'XHTML'                 ,
             'json'        => 'JSON'                  ,
             'jsp'         => 'JSP'                   , # Java server pages
             'jspf'        => 'JSP'                   , # Java server pages
@@ -4973,13 +5196,17 @@ sub set_constants {                          # {{{1
             'lhs'         => 'Haskell'               ,
             'l'           => 'lex'                   ,
             'less'        => 'LESS'                  ,
+            'liquid'      => 'liquid'                ,
             'lsp'         => 'Lisp'                  ,
             'lisp'        => 'Lisp'                  ,
+            'lgt'         => 'Logtalk'               ,
+            'logtalk'     => 'Logtalk'               ,
             'lua'         => 'Lua'                   ,
             'm3'          => 'Modula3'               ,
             'm4'          => 'm4'                    ,
             'makefile'    => 'make'                  ,
             'Makefile'    => 'make'                  ,
+            'md'          => 'Markdown'              ,
             'mc'          => 'Windows Message File'  ,
             'met'         => 'Teamcenter met'        ,
             'mg'          => 'Modula3'               ,
@@ -4989,8 +5216,11 @@ sub set_constants {                          # {{{1
             'mli'         => 'OCaml'                 ,
             'mly'         => 'OCaml'                 ,
             'mll'         => 'OCaml'                 ,
-            'm'           => 'MATLAB/Objective C/MUMPS/Mercury' ,
+            'm'           => 'MATLAB/Mathematica/Objective C/MUMPS/Mercury' ,
             'mm'          => 'Objective C++'         ,
+            'mt'          => 'Mathematica'           ,
+            'wl'          => 'Mathematica'           ,
+            'wlt'         => 'Mathematica'           ,
             'mustache'    => 'Mustache'              ,
             'wdproj'      => 'MSBuild script'        ,
             'csproj'      => 'MSBuild script'        ,
@@ -5053,12 +5283,14 @@ sub set_constants {                          # {{{1
             'srs'         => 'PowerBuilder'          ,
             'sru'         => 'PowerBuilder'          ,
             'srw'         => 'PowerBuilder'          ,
+            'pug'         => 'Pug'                   ,
             'purs'        => 'PureScript'            ,
             'prefab'      => 'Unity-Prefab'          ,
             'proto'       => 'Protocol Buffers'      ,
             'mat'         => 'Unity-Prefab'          ,
             'ps1'         => 'PowerShell'            ,
             'R'           => 'R'                     ,
+            'r'           => 'R'                     ,
             'rkt'         => 'Racket'                ,
             'rktl'        => 'Racket'                ,
             'ss'          => 'Racket'                ,
@@ -5077,6 +5309,7 @@ sub set_constants {                          # {{{1
             'sml'         => 'Standard ML'           ,
             'sig'         => 'Standard ML'           ,
             'fun'         => 'Standard ML'           ,
+            'slim'        => 'Slim'                  ,
             'sql'         => 'SQL'                   ,
             'SQL'         => 'SQL'                   ,
             'sproc.sql'   => 'SQL Stored Procedure'  ,
@@ -5093,7 +5326,12 @@ sub set_constants {                          # {{{1
             'tk'          => 'Tcl/Tk'                ,
             'tpl'         => 'Smarty'                ,
             'trigger'     => 'Apex Trigger'          ,
-            'ts'          => 'TypeScript'            ,
+            'ttcn'        => 'TTCN'                  ,
+            'ttcn2'       => 'TTCN'                  ,
+            'ttcn3'       => 'TTCN'                  ,
+            'ttcnpp'      => 'TTCN'                  ,
+            'tpd'         => 'TITAN Project File Information',
+            'ts'          => 'TypeScript/Qt Linguist',
             'tss'         => 'Titanium Style Sheet'  ,
             'twig'        => 'Twig'                  ,
             'ui'          => 'Qt'                    ,
@@ -5118,6 +5356,7 @@ sub set_constants {                          # {{{1
             'xml'         => 'XML'                   ,
             'XML'         => 'XML'                   ,
             'mxml'        => 'MXML'                  ,
+            'xml.builder' => 'builder'               ,
             'build'       => 'NAnt script'           ,
             'vim'         => 'vim script'            ,
             'swift'       => 'Swift'                 ,
@@ -5145,6 +5384,7 @@ sub set_constants {                          # {{{1
             'awk'      => 'awk'                   ,
             'bash'     => 'Bourne Again Shell'    ,
             'bc'       => 'bc'                    ,# calculator
+            'crystal'  => 'Crystal'               ,
             'csh'      => 'C Shell'               ,
             'dmd'      => 'D'                     ,
             'dtrace'   => 'dtrace'                ,
@@ -5164,6 +5404,7 @@ sub set_constants {                          # {{{1
             'python3'  => 'Python'                ,
             'python3.3'=> 'Python'                ,
             'python3.4'=> 'Python'                ,
+            'python3.5'=> 'Python'                ,
             'rexx'     => 'Rexx'                  ,
             'regina'   => 'Rexx'                  ,
             'ruby'     => 'Ruby'                  ,
@@ -5178,12 +5419,14 @@ sub set_constants {                          # {{{1
             );
 # 1}}}
 %{$rh_Language_by_File}      = (             # {{{1
+            'build.xml'      => 'Ant/XML'            ,
+            'CMakeLists.txt' => 'CMake'              ,
+            'Jamfile'        => 'Jam'                ,
+            'Jamrules'       => 'Jam'                ,
             'Makefile'       => 'make'               ,
             'makefile'       => 'make'               ,
             'gnumakefile'    => 'make'               ,
             'Gnumakefile'    => 'make'               ,
-            'CMakeLists.txt' => 'CMake'              ,
-            'build.xml'      => 'Ant/XML'            ,
             'pom.xml'        => 'Maven/XML'          ,
             'Rakefile'       => 'Ruby'               ,
             'rakefile'       => 'Ruby'               ,
@@ -5251,6 +5494,10 @@ sub set_constants {                          # {{{1
                                 [ 'remove_matches'      , '^\s*#'  ],
                                 [ 'remove_inline'       , '#.*$'   ],
                             ],
+    'Blade'              => [
+                                [ 'remove_between_general', '{{--', '--}}' ],
+                                [ 'remove_html_comments',                  ],
+                            ],
     'Bourne Again Shell' => [
                                 [ 'remove_matches'      , '^\s*#'  ],
                                 [ 'remove_inline'       , '#.*$'   ],
@@ -5258,6 +5505,13 @@ sub set_constants {                          # {{{1
     'Bourne Shell'       => [
                                 [ 'remove_matches'      , '^\s*#'  ],
                                 [ 'remove_inline'       , '#.*$'   ],
+                            ],
+    'Brainfuck'          => [ # puerile name for a language
+#                               [ 'call_regexp_common'  , 'Brainfuck' ],  # inaccurate
+                                [ 'remove_bf_comments',               ],
+                            ],
+    'builder'            => [
+                                [ 'remove_matches'      , '^\s*xml_markup.comment!'  ],
                             ],
     'C'                  => [
                                 [ 'call_regexp_common'  , 'C++'    ],
@@ -5278,6 +5532,10 @@ sub set_constants {                          # {{{1
     'ClojureScript'      => [   [ 'remove_matches'      , '^\s*;'  ], ],
     'ClojureC'           => [   [ 'remove_matches'      , '^\s*;'  ], ],
     'CMake'              => [
+                                [ 'remove_matches'      , '^\s*#'  ],
+                                [ 'remove_inline'       , '#.*$'   ],
+                            ],
+    'Crystal'            => [
                                 [ 'remove_matches'      , '^\s*#'  ],
                                 [ 'remove_inline'       , '#.*$'   ],
                             ],
@@ -5415,6 +5673,10 @@ sub set_constants {                          # {{{1
                                 [ 'call_regexp_common'  , 'Pascal' ],
                                 [ 'remove_matches'      , '^\s*//' ],
                             ],
+    'GDScript'           => [
+                                [ 'remove_matches'      , '^\s*#'  ],
+                                [ 'remove_inline'       , '#.*$'   ],
+                            ],
     'Go'                 => [
                                 [ 'call_regexp_common'  , 'C++'    ],
                                 [ 'remove_inline'       , '//.*$'  ],
@@ -5463,11 +5725,19 @@ sub set_constants {                          # {{{1
                                 [ 'remove_html_comments',          ],
                                 [ 'call_regexp_common'  , 'HTML'   ],
                             ],
+    'XHTML'               => [
+                                [ 'remove_html_comments',          ],
+                                [ 'call_regexp_common'  , 'HTML'   ],
+                            ],
     'Haskell'            => [   [ 'remove_haskell_comments', '>filename<' ], ],
     'IDL'                => [   [ 'remove_matches'      , '^\s*;'  ], ],
     'IDL/Qt Project/Prolog' => [ [ 'die' ,          ], ], # never called
     'InstallShield'      => [   [ 'remove_html_comments',          ],
                                 [ 'call_regexp_common'  , 'HTML'   ], ],
+    'Jam'                => [
+                                [ 'remove_matches'      , '^\s*#'  ],
+                                [ 'remove_inline'       , '#.*$'   ],
+                            ],
     'JSP'                => [   [ 'remove_html_comments',          ],
                                 [ 'call_regexp_common'  , 'HTML'   ],
                                 [ 'remove_jsp_comments' ,          ],
@@ -5486,6 +5756,11 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , '//.*$'  ],
                             ],
     'JavaScript'         => [
+#                               [ 'remove_matches'      , '^\s*//' ],
+                                [ 'call_regexp_common'  , 'C++'    ],
+                                [ 'remove_inline'       , '//.*$'  ],
+                            ],
+    'JSX'                => [
 #                               [ 'remove_matches'      , '^\s*//' ],
                                 [ 'call_regexp_common'  , 'C++'    ],
                                 [ 'remove_inline'       , '//.*$'  ],
@@ -5512,6 +5787,11 @@ sub set_constants {                          # {{{1
                                 [ 'call_regexp_common'  , 'C++'    ],
                                 [ 'remove_inline'       , '//.*$'  ],
                             ],
+    'liquid'             => [
+                                [ 'remove_between_general', '{% comment %}', 
+                                                            '{% endcomment %}' ],
+                                [ 'remove_html_comments',          ],
+                            ],
     'Lisp'               => [
                                 [ 'remove_matches'      , '^\s*;'  ],
                                 [ 'remove_between_general', '#|', '|#' ],
@@ -5519,6 +5799,11 @@ sub set_constants {                          # {{{1
     'Lisp/OpenCL'        => [ [ 'die' ,          ], ], # never called
     'Lisp/Julia'         => [ [ 'die' ,          ], ], # never called
     'LiveLink OScript'   => [   [ 'remove_matches'      , '^\s*//' ], ],
+    'Logtalk'            => [  # same filters as Prolog
+                                [ 'remove_matches'      , '^\s*\%' ],
+                                [ 'call_regexp_common'  , 'C'      ],
+                                [ 'remove_inline'       , '(//|\%).*$' ],
+                            ],
 #   'Lua'                => [   [ 'call_regexp_common'  , 'lua'    ], ],
     'Lua'                => [   [ 'remove_matches'      , '^\s*\-\-' ], ],
     'make'               => [
@@ -5528,6 +5813,9 @@ sub set_constants {                          # {{{1
     'MATLAB'             => [
                                 [ 'remove_matches'      , '^\s*%'  ],
                                 [ 'remove_inline'       , '%.*$'   ],
+                            ],
+    'Mathematica'        => [
+                                [ 'remove_between_general', '(*', '*)' ],
                             ],
     'Maven/XML'          => [
                                 [ 'remove_html_comments',          ],
@@ -5568,7 +5856,12 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , '//.*$'  ], # C99
                             ],
     'PHP/Pascal'               => [ [ 'die' ,          ], ], # never called
-    'MATLAB/Objective C/MUMPS/Mercury' => [ [ 'die' ,          ], ], # never called
+    'Markdown'           => [
+                                [ 'remove_between_regex',
+                                  '\[(comment|\/\/)?\]\s*:?\s*(<\s*>|#)?\s*\(.*?', '.*?\)' ],
+                                # http://stackoverflow.com/questions/4823468/comments-in-markdown
+                            ],
+    'MATLAB/Mathematica/Objective C/MUMPS/Mercury' => [ [ 'die' ,          ], ], # never called
     'MUMPS'              => [   [ 'remove_matches'      , '^\s*;'  ], ],
     'Mustache'           => [
                                 [ 'remove_between_general', '{{!', '}}' ],
@@ -5639,6 +5932,11 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , '//.*$'  ],
                                 [ 'call_regexp_common'  , 'C++'    ],
                             ],
+    'Pug'                => [
+                                [ 'remove_pug_block'    ,          ],
+                                [ 'remove_matches'      , '^\s*//' ],
+                                [ 'remove_inline'       , '//.*$'  ],
+                            ],
     'Python'             => [
                                 [ 'remove_matches'      , '^\s*#'  ],
                                 [ 'docstring_to_C'                 ],
@@ -5650,7 +5948,7 @@ sub set_constants {                          # {{{1
 #                               [ 'remove_matches'      , '^\s*//' ],
                                 [ 'call_regexp_common'  , 'C++'    ],
                                 [ 'remove_inline'       , '#.*$'   ],
-                                [ 'remove_inline'       , '//.*$'  ],
+#                               [ 'remove_inline'       , '//.*$'  ],
                             ],
     'QML'                => [
 #                               [ 'remove_matches'      , '^\s*//' ],
@@ -5658,6 +5956,10 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , '//.*$'  ],
                             ],
     'Qt'                 => [
+                                [ 'remove_html_comments',          ],
+                                [ 'call_regexp_common'  , 'HTML'   ],
+                            ],
+    'Qt Linguist'        => [
                                 [ 'remove_html_comments',          ],
                                 [ 'call_regexp_common'  , 'HTML'   ],
                             ],
@@ -5711,6 +6013,9 @@ sub set_constants {                          # {{{1
 #                               [ 'remove_matches'      , '^\s*//' ],
                                 [ 'remove_inline'       , '//.*$'  ],
                                 [ 'call_regexp_common'  , 'C++'    ],
+                            ],
+    'Slim'               => [
+                                [ 'remove_slim_block'   ,          ],
                             ],
     'SKILL'              => [
                                 [ 'call_regexp_common'  , 'C'      ],
@@ -5784,6 +6089,14 @@ sub set_constants {                          # {{{1
                             ],
     'Twig'               => [
                                 [ 'remove_between_general', '{#', '#}' ],
+                            ],
+    'TTCN'               => [
+                                [ 'call_regexp_common'  , 'C++'      ],
+                                [ 'remove_inline'       , '//.*$'  ],
+                            ],
+    'TITAN Project File Information'               => [
+                                [ 'remove_html_comments',          ],
+                                [ 'call_regexp_common'  , 'HTML'   ],
                             ],
     'TypeScript'         => [
 #                               [ 'remove_matches'      , '^\s*//' ],
@@ -5968,6 +6281,7 @@ sub set_constants {                          # {{{1
     'IDL'                =>     '\$\\$'         ,
     'Java'               =>     '\\\\$'         ,
     'JavaScript'         =>     '\\\\$'         ,
+    'JSX'                =>     '\\\\$'         ,
     'LESS'               =>     '\\\\$'         ,
     'Lua'                =>     '\\\\$'         ,
     'make'               =>     '\\\\$'         ,
@@ -5993,6 +6307,7 @@ sub set_constants {                          # {{{1
     'Korn Shell'         =>     '\\\\$'         ,
     'Stylus'             =>     '\\\\$'         ,
     'Tcl/Tk'             =>     '\\\\$'         ,
+    'TTCN'               =>     '\\\\$'         ,
     'TypeScript'         =>     '\\\\$'         ,
     'lex'                =>     '\\\\$'         ,
     'Vala'               =>     '\\\\$'         ,
@@ -6180,10 +6495,13 @@ sub set_constants {                          # {{{1
     'bc'                           =>   1.50,
     'berkeley pascal'              =>   0.88,
     'better basic'                 =>   0.88,
+    'Blade'                        =>   2.00,
     'bliss'                        =>   0.75,
     'bmsgen'                       =>   2.22,
     'boeingcalc'                   =>  13.33,
     'bteq'                         =>   6.15,
+    'Brainfuck'                    =>   0.10,
+    'builder'                      =>   2.00,
     'C'                            =>   0.77,
     'c set 2'                      =>   0.88,
     'C#'                           =>   1.36,
@@ -6234,6 +6552,7 @@ sub set_constants {                          # {{{1
     'corvet'                       =>   4.21,
     'corvision'                    =>   5.33,
     'cpl'                          =>   0.50,
+    'Crystal'                      =>   2.50,
     'Crystal Reports'              =>   4.00,
     'csl'                          =>   1.63,
     'CSON'                         =>   2.50,
@@ -6333,6 +6652,7 @@ sub set_constants {                          # {{{1
     'gpss'                         =>   1.74,
     'guest'                        =>   2.86,
     'guru'                         =>   1.63,
+    'GDScript'                     =>   2.50,
     'Go'                           =>   2.50,
     'Grails'                       =>   1.48,
     'Groovy'                       =>   4.10,
@@ -6345,6 +6665,7 @@ sub set_constants {                          # {{{1
     'Haml'                         =>   2.50,
     'Handlebars'                   =>   2.50,
     'HTML'                         =>   1.90,
+    'XHTML'                        =>   1.90,
     'XMI'                          =>   1.90,
     'XML'                          =>   1.90,
     'MXML'                         =>   1.90,
@@ -6386,12 +6707,14 @@ sub set_constants {                          # {{{1
     'iqlisp'                       =>   1.38,
     'iqrp'                         =>   6.15,
     'j2ee'                         =>   1.60,
+    'Jam'                          =>   2.00,
     'janus'                        =>   1.13,
     'Java'                         =>   1.36,
     'JavaScript'                   =>   1.48,
     'JavaServer Faces'             =>   1.5 ,
     'JSON'                         =>   2.50,
     'JSP'                          =>   1.48,
+    'JSX'                          =>   1.48,
     'Velocity Template Language'   =>   1.00,
     'JCL'                          =>   1.67,
     'joss'                         =>   0.75,
@@ -6416,9 +6739,11 @@ sub set_constants {                          # {{{1
     'liana'                        =>   0.63,
     'lilith'                       =>   1.13,
     'linc ii'                      =>   5.71,
+    'liquid'                       =>   3.00,
     'Lisp'                         =>   1.25,
     'LiveLink OScript'             =>   3.5 ,
     'loglisp'                      =>   1.38,
+    'Logtalk'                      =>   2.00,
     'loops'                        =>   3.81,
     'lotus 123 dos'                =>  13.33,
     'lotus macros'                 =>   0.75,
@@ -6439,6 +6764,7 @@ sub set_constants {                          # {{{1
     'mapper'                       =>   0.99,
     'mark iv'                      =>   2.00,
     'mark v'                       =>   2.22,
+    'Markdown'                     =>   1.00,
     'mathcad'                      =>  16.00,
     'Maven'                        =>   1.90,
     'mdl'                          =>   2.22,
@@ -6533,6 +6859,7 @@ sub set_constants {                          # {{{1
     'prose'                        =>   0.75,
     'proteus'                      =>   0.75,
     'Protocol Buffers'             =>   2.00,
+    'Pug'                          =>   2.00,
     'Puppet'                       =>   2.00,
     'PureScript'                   =>   2.00,
     'qbasic'                       =>   1.38,
@@ -6540,6 +6867,7 @@ sub set_constants {                          # {{{1
     'qmf'                          =>   5.33,
     'QML'                          =>   1.25,
     'Qt'                           =>   2.00,
+    'Qt Linguist'                  =>   1.00,
     'Qt Project'                   =>   1.00,
     'qnial'                        =>   1.63,
     'quattro'                      =>  13.33,
@@ -6585,6 +6913,7 @@ sub set_constants {                          # {{{1
     'scheme'                       =>   1.51,
     'screen painter default'       =>  13.33,
     'sequal'                       =>   6.67,
+    'Slim'                         =>   3.00,
     'Bourne Shell'                 =>   3.81,
     'Bourne Again Shell'           =>   3.81,
     'ksh'                          =>   3.81,
@@ -6662,6 +6991,8 @@ sub set_constants {                          # {{{1
     'tutor'                        =>   1.51,
     'twaice'                       =>   1.63,
     'Twig'                         =>   2.00,
+    'TTCN'                         =>   2.00,
+    'TITAN Project File Information' =>   1.90,
     'TypeScript'                   =>   2.00,
     'ucsd pascal'                  =>   0.88,
     'ufo/ims'                      =>   2.22,
@@ -6734,6 +7065,7 @@ sub set_constants {                          # {{{1
     'lex'                          => 1.00,
     'Julia'                        => 4.00,
     'MATLAB'                       => 4.00,
+    'Mathematica'                  => 5.00,
     'Mercury'                      => 3.00,
     'Maven/XML'                    => 2.5,
     'IDL'                          => 3.80,
@@ -6748,9 +7080,6 @@ sub set_constants {                          # {{{1
     'sed'                          => 4.00,
     'Lua'                          => 4.00,
     'OpenCL'                       => 1.50,
-#   'Lisp/Julia'                   => 4.00,
-#   'Lisp/OpenCL'                  => 1.50,
-#   'MATLAB/Objective C/MUMPS/Mercury' => 3.00,
 );
 # 1}}}
 %{$rh_Known_Binary_Archives} = (             # {{{1
@@ -6778,7 +7107,7 @@ sub check_scale_existence {                  # {{{1
         "PHP/Pascal"                        => 1,
         "Lisp/OpenCL"                       => 1,
         "Lisp/Julia"                        => 1,
-        "MATLAB/Objective C/MUMPS/Mercury"  => 1,
+        "MATLAB/Mathematica/Objective C/MUMPS/Mercury"  => 1,
         "Pascal/Puppet"                     => 1,
         "Perl/Prolog"                       => 1,
         "IDL/Qt Project/Prolog"             => 1,
@@ -6786,6 +7115,7 @@ sub check_scale_existence {                  # {{{1
         "Fortran 77/Forth"                  => 1,
         "F#/Forth"                          => 1,
         "Verilog-SystemVerilog/Coq"         => 1,
+        "TypeScript/Qt Linguist"            => 1,
     );
     my $OK = 1;
     foreach my $language (sort keys %{$rhaa_Filters_by_Language}) {
@@ -7150,7 +7480,7 @@ my @generic = (
      from_to   => [['<?_c', '_c?>']],
     },
 
-    {languages => [qw /C++/, 'C#', qw /AspectJ Cg ECMAScript FPL Java JavaScript Stylus/],
+    {languages => [qw /C++/, 'C#', qw /AspectJ Cg ECMAScript FPL Java JavaScript JSX Stylus/],
      to_eol    => ['//'],
      from_to   => [[qw {/* */}]]},
 
@@ -7418,7 +7748,7 @@ pattern name    =>  [qw /comment Fortran fixed/],
 
 
 # http://www.csis.ul.ie/cobol/Course/COBOLIntro.htm
-# Traditionally, comments in COBOL were indicated with an asteriks in
+# Traditionally, comments in COBOL were indicated with an asterisk in
 # the seventh column. Modern compilers may be more lenient.
 pattern name    =>  [qw /comment COBOL/],
         create  =>  '(?<=^......)(?k:(?k:[*])(?k:[^\n]*)(?k:\n))',
@@ -8532,7 +8862,7 @@ sub plural_form {                            # {{{1
     else         { return ($n, "s"); }
 } # 1}}}
 sub matlab_or_objective_C {                  # {{{1
-    # Decide if code is MATLAB, Objective C, MUMPS, or Mercury
+    # Decide if code is MATLAB, Mathematica, Objective C, MUMPS, or Mercury
     my ($file        , # in
         $rh_Err      , # in   hash of error codes
         $raa_errors  , # out
@@ -8558,6 +8888,10 @@ sub matlab_or_objective_C {                  # {{{1
     #
     # Mercury:
     #   any line that begins with :- immediately triggers this
+    #
+    # Mathematica:
+    #   (* .. *)
+    #   BeginPackage
 
     ${$rs_language} = "";
     my $IN = new IO::File $file, "r";
@@ -8569,6 +8903,7 @@ sub matlab_or_objective_C {                  # {{{1
     my $DEBUG              = 0;
 
     my $matlab_points      = 0;
+    my $mathematica_points = 0;
     my $objective_C_points = 0;
     my $mumps_points       = 0;
     my $mercury_points     = 0;
@@ -8580,66 +8915,73 @@ sub matlab_or_objective_C {                  # {{{1
         if      (m{^\s*/\*} or m {^\s*//}) {   #   /* or //
             $objective_C_points += 5;
             $matlab_points      -= 5;
-printf ".m:  /*|//  obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m:  /*|//  obj C=% 2d  matlab=% 2d  mathematica=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         } elsif (m{^:-\s+}) {      # gotta be mercury
             $mercury_points = 1000;
             last;
         } elsif (m{\w+\s*=\s*\[}) {      # matrix assignment, very matlab
             $matlab_points += 5;
-printf ".m:  \\w=[   obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+        }
+        if (m{\w+\[}) {      # function call by []
+            $mathematica_points += 2;
+printf ".m:  \\w=[   obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         } elsif (m{^\s*\w+\s*=\s*}) {    # definitely not MUMPS
             --$mumps_points;
-printf ".m:  \\w=    obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m:  \\w=    obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         } elsif (m{^\s*\.?(\w)\s+(\w)} and $1 !~ /\d/ and $2 !~ /\d/) {
             ++$mumps_points;
-printf ".m:  \\w \\w  obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m:  \\w \\w  obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         } elsif (m{^\s*;}) {
             ++$mumps_points;
-printf ".m:  ;      obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
-        } elsif (m{^\s*#(include|import)}) {
+printf ".m:  ;      obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
+        }
+        if (m{^\s*#(include|import)}) {
             # Objective C without a doubt
             $objective_C_points = 1000;
             $matlab_points      = 0;
-printf ".m: #includ obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m: #includ obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
             $has_braces         = 2;
             last;
         } elsif (m{^\s*@(interface|implementation|protocol|public|protected|private|end)\s}o) {
             # Objective C without a doubt
             $objective_C_points = 1000;
             $matlab_points      = 0;
-printf ".m: keyword obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m: keyword obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
             last;
+        } elsif (m{^\s*BeginPackage}) {
+            $mathematica_points += 2;
         } elsif (m{^\s*\[}) {             #   line starts with [  -- very matlab
             $matlab_points += 5;
-printf ".m:  [      obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m:  [      obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         } elsif (m{^\sK(ill)?\s+}) {
             $mumps_points  += 5;
-printf ".m:  Kill   obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m:  Kill   obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         } elsif (m{^\s*function}) {
             --$objective_C_points;
             ++$matlab_points;
-printf ".m:  funct  obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m:  funct  obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         } elsif (m{^\s*%}) {              #   %
             # matlab commented line
             --$objective_C_points;
             ++$matlab_points;
-printf ".m:  pcent  obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf ".m:  pcent  obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
         }
     }
     $IN->close;
-printf "END LOOP    obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mumps_points, $mercury_points if $DEBUG;
+printf "END LOOP    obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $objective_C_points, $matlab_points, $mathematica_points, $mumps_points, $mercury_points if $DEBUG;
 
     # next heuristic is unreliable for small files
 #   $objective_C_points = -9.9e20 unless $has_braces >= 2;
 
     my %points = ( 'MATLAB'      => $matlab_points     ,
+                   'Mathematica' => $mathematica_points     ,
                    'MUMPS'       => $mumps_points      ,
                    'Objective C' => $objective_C_points,
                    'Mercury'     => $mercury_points    , );
 
     ${$rs_language} = (sort { $points{$b} <=> $points{$a}} keys %points)[0];
 
-    print "<- matlab_or_objective_C($file: matlab=$matlab_points, C=$objective_C_points, mumps=$mumps_points, mercury=$mercury_points) => ${$rs_language}\n"
+    print "<- matlab_or_objective_C($file: matlab=$matlab_points, mathematica=$mathematica_points, C=$objective_C_points, mumps=$mumps_points, mercury=$mercury_points) => ${$rs_language}\n"
         if $opt_v > 2;
 
 } # 1}}}
@@ -8884,6 +9226,12 @@ sub pascal_or_puppet {                       # {{{1
     my $puppet_points      = 0;
 
     while (<$IN>) {
+
+        if ( /^\s*\#\s+/ ) {
+                $puppet_points += .001;
+                next;
+        }
+
         ++$pascal_points if /\bprogram\s+[A-Za-z]/i;
         ++$pascal_points if /\bunit\s+[A-Za-z]/i;
         ++$pascal_points if /\bmodule\s+[A-Za-z]/i;
@@ -8891,14 +9239,26 @@ sub pascal_or_puppet {                       # {{{1
         ++$pascal_points if /\bfunction\b/i;
         ++$pascal_points if /^\s*interface\s+/i;
         ++$pascal_points if /^\s*implementation\s+/i;
-        ++$pascal_points if /\bbegin\b/i;
-        ++$pascal_points if /\bend\b/i;
+        ++$pascal_points if /^\s*uses\s+/i;
+        ++$pascal_points if /(?<!\:\:)\bbegin\b(?!\:\:)/i;
+        ++$pascal_points if /(?<!\:\:)\bend\b(?!\:\:)/i;
+        ++$pascal_points if /\:\=/;
+        ++$pascal_points if /\<\>/;
+        ++$pascal_points if /^\s*\{\$(I|INCLUDE)\s+.*\}/i;
+        ++$pascal_points if /writeln/;
 
-        ++$puppet_points if /^\s*class\s+/;
+        ++$puppet_points if /^\s*class\s+/ and not /class\s+operator\s+/;
         ++$puppet_points if /^\s*case\s+/;
         ++$puppet_points if /^\s*package\s+/;
         ++$puppet_points if /^\s*file\s+/;
+        ++$puppet_points if /^\s*include\s\w+/;
         ++$puppet_points if /^\s*service\s+/;
+        ++$puppet_points if /\s\$\w+\s*\=\s*\S/;
+        ++$puppet_points if /\S\s*\=\>\s*\S/;
+
+        # No need to process rest of file if language seems obvious.
+        last
+                if (abs ($pascal_points - $puppet_points ) > 20 );
     }
     $IN->close;
 
@@ -8991,7 +9351,11 @@ sub Verilog_or_Coq {                         # {{{1
     while (<$IN>) {
         ++$verilog_points if  /^\s*(module|begin|input|output|always)/;
         ++$coq_points if /\b(Inductive|Fixpoint|Definition|
-                             Theorem|Lemma|Proof|Qed|forall)\b/x;
+                             Theorem|Lemma|Proof|Qed|forall|
+                             Section|Check|Notation|Variable|
+                             Goal|Fail|Require|Scheme|Module|Ltac|
+                             Set|Unset|Parameter|Coercion|Axiom|
+                             Locate|Type|Record|Existing|Class)\b/x;
     }
     $IN->close;
     if ($coq_points > $verilog_points) {
@@ -9001,6 +9365,37 @@ sub Verilog_or_Coq {                         # {{{1
     }
 
     print "<- Verilog_or_Coq\n" if $opt_v > 2;
+    return $lang;
+} # 1}}}
+sub TypeScript_or_QtLinguist {               # {{{1
+    my ($file        , # in
+        $rh_Err      , # in   hash of error codes
+        $raa_errors  , # out
+       ) = @_;
+
+    print "-> TypeScript_or_QtLinguist\n" if $opt_v > 2;
+
+    my $lang = undef;
+    my $IN = new IO::File $file, "r";
+    if (!defined $IN) {
+        push @{$raa_errors}, [$rh_Err->{'Unable to read'} , $file];
+        return $lang;
+    }
+    my $tscript_points  = 0;
+    my $linguist_points = 0;
+    while (<$IN>) {
+        ++$linguist_points if m{\b</?(message|source|translation)>};
+        ++$tscript_points  if /^\s*(var|class|document)\b/;
+        ++$tscript_points  if /[;}]\s*$/;
+        ++$tscript_points  if m{^\s*//};
+    }
+    $IN->close;
+    if ($tscript_points > $linguist_points) {
+        $lang = "TypeScript";
+    } else {
+        $lang = "Qt Linguist";
+    }
+    print "<- TypeScript_or_QtLinguist\n" if $opt_v > 2;
     return $lang;
 } # 1}}}
 sub html_colored_text {                      # {{{1
@@ -9966,7 +10361,7 @@ sub read_list_file {                         # {{{1
     my $IN = new IO::File $file, "r";
     if (!defined $IN) {
         warn "Unable to read $file; ignoring.\n";
-        next;
+        return ();
     }
     my @entry = ();
     while (<$IN>) {
@@ -10432,6 +10827,9 @@ sub normalize_file_names {                   # {{{1
                 $F_norm = lc "$cwd/$F_norm";
             }
         }
+        # Remove trailing / so it does not interfere with further regex code
+        # that does not expect it
+        $F_norm =~ s{/+$}{};
         $normalized{ $F_norm } = $F;
     }
     return %normalized;
@@ -10735,9 +11133,9 @@ sub really_is_incpascal {                    # {{{1
  my $filename = shift;
  chomp($filename);
 
-# The heuristic is as follows: it is Pacal if any of the following:
+# The heuristic is as follows: it is Pascal if any of the following:
 # 1. really_is_pascal returns true
-# 2. Any usual reserverd word is found (program, unit, const, begin...)
+# 2. Any usual reserved word is found (program, unit, const, begin...)
 
  # If the general routine for Pascal files works, we have it
  if (really_is_pascal($filename)) {


### PR DESCRIPTION
The source code is well documented. It is compatible with Python 2 and 3, and does not require any third-party packages: the four packages: os, sys, getopt, subprocess, come with Python by default.
....................................................
"clocs" is a wrapper script of "cloc", written in python. It can count lines of code within a project directory and/or its subdirectories (the subdirectories' names are automatically acquired by the code, at line 25-28. In my project, "cloc" is in (project)/tools/third-party/, and "clocs" is in (project)/tools/.
The file excluded-files-list required by "cloc --exclude-list-file" should be in (project)/tools/third-party/, as indicated at line 31.
....................................................
Usage: 
"clocs -h" for helper, 
"clocs -c" to clean all reports (named "stat.txt"), 
"clocs -a" to generate "cloc" reports in the project directory and all subdirectories,
"clocs (subdirectory-name)" to generate a report directly in the subdirectory,
"clocs ." or "clocs" to generate a report directly in the project directory.
....................................................
Developed on Mac 10.12, tested on Mac 10.12 and Ubuntu 14.04. Feedback is welcome:)
....................................................
Oh, you can delete the copyright disclaimer at the beginning of this file. This file was part of my own project but I'd like to share it. Also feel free to modify the code.