### PR TITLE
Add Python Test and Single Quote Docstring

### DIFF
--- a/Unix/t/00_C.t
+++ b/Unix/t/00_C.t
@@ -401,6 +401,11 @@ my @Tests = (   {
                     'args' => '../tests/inputs/modules1-ntp1.pp',
                 },
                 {
+                    'name' => 'Python',
+                    'ref'  => '../tests/outputs/hi.py.yaml',
+                    'args' => '../tests/inputs/hi.py',
+                },
+                {
                     'name' => 'Qt Linguist',
                     'ref'  => '../tests/outputs/i18n_de.ts.yaml',
                     'args' => '../tests/inputs/i18n_de.ts',

--- a/cloc
+++ b/cloc
@@ -5186,12 +5186,12 @@ sub docstring_to_C {                         # {{{1
 
     my $in_docstring = 0;
     foreach (@{$ra_lines}) {
-        while (/"""/) {
+        while (/((""")|('''))/) {
             if (!$in_docstring) {
-                s{[uU]?"""}{/*};
+                s{[uU]?((""")|('''))}{/*};
                 $in_docstring = 1;
             } else {
-                s{"""}{*/};
+                s{((""")|('''))}{*/};
                 $in_docstring = 0;
             }
         }

--- a/tests/inputs/hi.py
+++ b/tests/inputs/hi.py
@@ -10,3 +10,8 @@ print('Hello.  The time is %f Unix epoch.' % (time.time()))  # inline comment
 Docstring,
   also counted as comment.
 """
+
+'''
+Single
+  Quoted
+    Docstring'''

--- a/tests/outputs/hi.py.yaml
+++ b/tests/outputs/hi.py.yaml
@@ -1,0 +1,21 @@
+---
+# github.com/AlDanial/cloc
+header : 
+  cloc_url           : github.com/AlDanial/cloc
+  cloc_version       : 1.67
+  elapsed_seconds    : 0.0048980712890625
+  n_files            : 1
+  n_lines            : 12
+  files_per_second   : 204.16199376947
+  lines_per_second   : 2449.94392523364
+  report_file        : hi.py.yaml
+Python :
+  nFiles: 1
+  blank: 4
+  comment: 11
+  code: 2
+SUM: 
+  blank: 4
+  comment: 11
+  code: 2
+  nFiles: 1


### PR DESCRIPTION
Add single quoted docstring to tests/inputs/hi.py.
Add Python test output (tests/outputs/hi.py.yaml).
Add Python test entry to Unix/t/00_c.t.
Change docstring_to_C to check for ''' as well as """.