### PR TITLE
for -html option

### DIFF
--- a/cloc
+++ b/cloc
@@ -10975,7 +10975,7 @@ sub html_header {                            # {{{1
     return
 '<html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="GENERATOR" content="cloc http://cloc.sourceforge.net">
 ' .
 "


### PR DESCRIPTION
Html file can not display Chinese characters normally, so change charset=iso-8859-1 to charset=utf-8