### PR TITLE
Remove duplicate keys in language extensions.

### DIFF
--- a/cloc
+++ b/cloc
@@ -5960,7 +5960,6 @@ sub set_constants {                          # {{{1
             'xmi'         => 'XMI'                   ,
             'XMI'         => 'XMI'                   ,
             'xml'         => 'XML'                   ,
-            'xml'         => 'XML'                   ,
             'XML'         => 'XML'                   ,
             'mxml'        => 'MXML'                  ,
             'xml.builder' => 'builder'               ,


### PR DESCRIPTION
The 'xml' key is duplicate, should be removed.