### PR TITLE
Fix issue #22 - performance on multicore systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,12 @@ Usage: cloc [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <report 
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the
                              sum of data from the individual report files.
+   --processes=NUM	     Sets the maximum number of processes that cloc uses. If this
+                             parameter is set to 0, multiprocessing will not be used. On Unix systems,
+                             cloc tries to detect the number of CPU cores and creates
+                             up to one process for each core by default. On Windows systems
+                             and on systems with an unknown number of cores, 
+                             multiprocessing is disabled by default.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.

--- a/README.md
+++ b/README.md
@@ -677,12 +677,15 @@ Usage: cloc [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <report 
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the
                              sum of data from the individual report files.
-   --processes=NUM	     Sets the maximum number of processes that cloc uses. If this
-                             parameter is set to 0, multiprocessing will not be used. On Unix systems,
-                             cloc tries to detect the number of CPU cores and creates
-                             up to one process for each core by default. On Windows systems
-                             and on systems with an unknown number of cores, 
-                             multiprocessing is disabled by default.
+   --processes=NUM	     Sets the maximum number of processes that cloc
+                             uses. If this parameter is set to 0, multi-
+                             processing will not be used. On Linux systems,
+                             cloc tries to detect the number of CPU cores
+                             and creates up to one process per core by
+                             default. On systems with an unknown number
+                             of cores, using multiple processes is disabled
+                             by default. It is not possible to use multiple
+                             processes on Windows systems.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.

--- a/README.md
+++ b/README.md
@@ -677,15 +677,18 @@ Usage: cloc [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <report 
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the
                              sum of data from the individual report files.
-   --processes=NUM	     Sets the maximum number of processes that cloc
+   --processes=NUM           Sets the maximum number of processes that cloc
                              uses. If this parameter is set to 0, multi-
-                             processing will not be used. On Linux systems,
-                             cloc tries to detect the number of CPU cores
-                             and creates up to one process per core by
-                             default. On systems with an unknown number
-                             of cores, using multiple processes is disabled
-                             by default. It is not possible to use multiple
-                             processes on Windows systems.
+                             processing will not be used. On Linux and MacOS
+                             systems, cloc tries to detect the number of CPU
+                             cores and creates up to one process per core by
+                             default if a recent version of the
+                             Parallel::ForkManager module is available. On
+                             systems with an unknown number of cores and on
+                             systems which don't have a recent version of
+                             Parallel::ForkManager, using multiple processes
+                             is disabled by default. It is not possible to
+                             use multiple processes on Windows systems.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.

--- a/README.md
+++ b/README.md
@@ -679,16 +679,15 @@ Usage: cloc [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <report 
                              sum of data from the individual report files.
    --processes=NUM           Sets the maximum number of processes that cloc
                              uses. If this parameter is set to 0, multi-
-                             processing will not be used. On Linux and MacOS
-                             systems, cloc tries to detect the number of CPU
-                             cores and creates up to one process per core by
-                             default if a recent version of the
-                             Parallel::ForkManager module is available. On
-                             systems with an unknown number of cores and on
-                             systems which don't have a recent version of
-                             Parallel::ForkManager, using multiple processes
-                             is disabled by default. It is not possible to
-                             use multiple processes on Windows systems.
+                             processing will be disabled. On Linux and MacOS
+                             systems, cloc creates up to one process per core
+                             by default if a recent version of the
+                             Parallel::ForkManager module is available.
+                             Multiprocessing is disabled by default if cloc
+                             is unable to determine the number of CPU cores.
+                             Multiprocessing is not supported on Windows systems
+                             and on systems which don't have a recent version
+                             of the Parallel::ForkManager module.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.

--- a/cloc
+++ b/cloc
@@ -1823,9 +1823,14 @@ my %Results_by_Language = ();
 my %Results_by_File     = ();
 my @results_parts  = ();
 my @sorted_files = sort keys %unique_source_file;
+
 if ( $max_processes == 0) {
     # Multiprocessing is disabled    
-    push (@results_parts , count_files ( \@sorted_files , 0, \%Language));
+    my $part = count_files ( \@sorted_files , 0, \%Language);
+    %Results_by_File = %{$part->{'results_by_file'}};
+    %Results_by_Language= %{$part->{'results_by_language'}};
+    %Ignored = ( %Ignored, %{$part->{'ignored'}});
+    push ( @Errors, @{$part->{'errors'}});   
 }
 else {
     # Do not create more processes than the number of files to be processed
@@ -1859,6 +1864,7 @@ else {
             }
         }
         %Results_by_File = ( %Results_by_File, %$part_result_by_file );
+        %Ignored = (%Ignored, %$part_ignored);
         push ( @Errors, @$part_errors);
     } );
     my $num_files_per_part = ceil ( ( scalar @sorted_files ) / $num_processes );

--- a/cloc
+++ b/cloc
@@ -354,16 +354,15 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              sum of data from the individual report files.
    --processes=NUM           Sets the maximum number of processes that cloc
                              uses. If this parameter is set to 0, multi-
-                             processing will not be used. On Linux and MacOS
-                             systems, cloc tries to detect the number of CPU
-                             cores and creates up to one process per core by
-                             default if a recent version of the
-                             Parallel::ForkManager module is available. On
-                             systems with an unknown number of cores and on
-                             systems which don't have a recent version of
-                             Parallel::ForkManager, using multiple processes
-                             is disabled by default. It is not possible to
-                             use multiple processes on Windows systems.
+                             processing will be disabled. On Linux and MacOS
+                             systems, cloc creates up to one process per core
+                             by default if a recent version of the
+                             Parallel::ForkManager module is available.
+                             Multiprocessing is disabled by default if cloc
+                             is unable to determine the number of CPU cores.
+                             Multiprocessing is not supported on Windows systems
+                             and on systems which don't have a recent version
+                             of the Parallel::ForkManager module.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.

--- a/cloc
+++ b/cloc
@@ -354,9 +354,9 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              sum of data from the individual report files.
    --processes=NUM           Sets the maximum number of processes that cloc
                              uses. If this parameter is set to 0, multi-
-                             processing will not be used. On Linux systems,
-                             cloc tries to detect the number of CPU cores
-                             and creates up to one process per core by
+                             processing will not be used. On Linux and MacOS
+                             systems, cloc tries to detect the number of CPU
+                             cores and creates up to one process per core by
                              default. On systems with an unknown number
                              of cores, using multiple processes is disabled
                              by default. It is not possible to use multiple
@@ -1662,7 +1662,7 @@ if ($opt_count_diff) {
     goto Top_of_Processing_Loop;
 }
 sub get_max_processes {			     # {{{1
-    # If user has specified valid number of threads, use that.
+    # If user has specified valid number of processes, use that.
     if (defined $opt_processes) {
         if ( $opt_processes !~ /^\d+$/ ) {
             print "Error: processes option argument must be numeric.\n";
@@ -1686,20 +1686,30 @@ sub get_max_processes {			     # {{{1
     if ($ON_WINDOWS) {
         return 0;
     }
- 
+
     # Disable multiprocessing if Parallel::ForkManager is not available
     if ( ! $HAVE_Parallel_ForkManager ) {
         return 0;
     }
 
     # Set to number of cores on Linux
-    if ( -x '/usr/bin/nproc' ) {
-        my $numavcores = `/usr/bin/nproc`;
-        chomp $numavcores;
-        if ( $numavcores =~ /^\d+$/ ) {
-            return $numavcores;
+    if ( $^O =~ /linux/i and -x '/usr/bin/nproc' ) {
+        my $numavcores_linux = `/usr/bin/nproc`;
+        chomp $numavcores_linux;
+        if ( $numavcores_linux =~ /^\d+$/ ) {
+            return $numavcores_linux;
         }
     }
+
+    # Set to number of cores on MacOS
+    if ( $^O =~ /darwin/i and -x '/usr/sbin/sysctl') {
+       my $numavcores_macos = `/usr/sbin/sysctl -n hw.physicalcpu`;
+       chomp $numavcores_macos;
+       if ($numavcores_macos =~ /^\d+$/ ) {
+           return $numavcores_macos;
+       }
+    }
+
     # Disable multiprocessing in other cases
     return 0;
 } # 1}}}

--- a/cloc
+++ b/cloc
@@ -35,6 +35,7 @@ require 5.006;
 # use modules                                  {{{1
 use warnings;
 use strict;
+
 use Getopt::Long;
 use File::Basename;
 use File::Temp qw { tempfile tempdir };
@@ -42,6 +43,7 @@ use File::Find;
 use File::Path;
 use File::Spec;
 use IO::File;
+use List::Util qw( min max );
 use Cwd;
 use POSIX qw { strftime ceil};
 
@@ -1335,392 +1337,125 @@ my %Results_by_File     = ();
 my %Delta_by_Language   = ();
 my %Delta_by_File       = ();
 
-foreach (my $F = 0; $F < scalar @fh - 1; $F++) {
-    # loop over file sets; do diff between set $F to $F+1
+my @files_added_tot = ();
+my @files_removed_tot = ();
+my @file_pairs_tot = ();
+my @alignment = ();
 
-    my $nCounted = 0;
+my $fset_a = $fh[0];
+my $fset_b = $fh[1];
 
-    my @file_pairs    = ();
-    my @files_added   = ();
-    my @files_removed = ();
+my $n_filepairs_compared = 0;
+my $tot_counted = 0;
 
-    align_by_pairs(\%{$unique_source_file{$fh[$F  ]}}    , # in
-                   \%{$unique_source_file{$fh[$F+1]}}    , # in
-                   \@files_added                         , # out
-                   \@files_removed                       , # out
-                   \@file_pairs                          , # out
-                   );
-    my %already_counted = (); # already_counted{ filename } = 1
+if ( scalar @fh != 2 ) {
+    print "Error: in correct length fh array when preparing diff at step 6.\n";
+    exit 1;
+}
 
-    if (!@file_pairs) {
-        # Special case where all files were either added or deleted.
-        # In this case, one of these arrays will be empty:
-        #   @files_added, @files_removed
-        # so loop over both to cover both cases.
-        my $status = @files_added ? 'added' : 'removed';
-        my $offset = @files_added ? 1       : 0        ;
-        foreach my $file (@files_added, @files_removed) {
-            next unless defined $Language{$fh[$F+$offset]}{$file};
-            my $Lang = $Language{$fh[$F+$offset]}{$file};
-            next if $Lang eq '(unknown)';
-            my ($all_line_count,
-                $blank_count   ,
-                $comment_count ,
-               ) = call_counter($file, $Lang, \@Errors);
-            $already_counted{$file} = 1;
-            my $code_count = $all_line_count-$blank_count-$comment_count;
-            if ($opt_by_file) {
-                $Delta_by_File{$file}{'code'   }{$status} += $code_count   ;
-                $Delta_by_File{$file}{'blank'  }{$status} += $blank_count  ;
-                $Delta_by_File{$file}{'comment'}{$status} += $comment_count;
-                $Delta_by_File{$file}{'lang'   }{$status}  = $Lang         ;
-                $Delta_by_File{$file}{'nFiles' }{$status} += 1             ;
+align_by_pairs        (\%{$unique_source_file{$fset_a}}      , # in
+                       \%{$unique_source_file{$fset_b}}      , # in
+                       \@files_added_tot                     , # out
+                       \@files_removed_tot                   , # out
+                       \@file_pairs_tot                      , # out
+                      );
+
+
+if ( $max_processes == 0) {
+    # Multiprocessing is disabled    
+    my $part = count_filesets ( $fset_a, $fset_b, \@files_added_tot, \@files_removed_tot, \@file_pairs_tot , 0, \%Language);
+    %Results_by_File = %{$part->{'results_by_file'}};
+    %Results_by_Language= %{$part->{'results_by_language'}};
+    %Delta_by_File = %{$part->{'delta_by_file'}};
+    %Delta_by_Language= %{$part->{'delta_by_language'}};
+    %Ignored = ( %Ignored, %{$part->{'ignored'}});
+    @alignment = @{$part->{'alignment'}};
+    $n_filepairs_compared = $part->{'n_filepairs_compared'};
+    push ( @Errors, @{$part->{'errors'}});   
+}
+else {
+    # Multiprocessing is enabled
+    # Do not create more processes than the amount of data to be processed
+    my $num_processes = min(max(scalar @files_added_tot,scalar @files_removed_tot,scalar @file_pairs_tot),$max_processes);
+    # ... but use at least one process.
+       $num_processes = 1
+            if $num_processes == 0;
+    # Start processes for counting
+    my $pm = Parallel::ForkManager->new($num_processes);
+    # When processes finish, they will use the embedded subroutine for
+    # merging the data into global variables.
+    $pm->run_on_finish ( sub {
+        my ($pid, $exit_code, $ident, $exit_signal, $core_dump, $part) = @_;
+        my $part_ignored = $part->{'ignored'};
+        my $part_result_by_file = $part->{'results_by_file'};
+        my $part_result_by_language = $part->{'results_by_language'};
+        my $part_delta_by_file = $part->{'delta_by_file'};
+        my $part_delta_by_language = $part->{'delta_by_language'};
+        my $part_alignment = $part->{'alignment'};
+        my $part_errors = $part->{'errors'};
+           $tot_counted += scalar keys %$part_result_by_file;
+           $n_filepairs_compared += $part->{'n_filepairs_compared'};
+        # Since files are processed by multiple processes, we can't measure
+        # the number of processed files exactly. We approximate this by showing
+        # the number of files counted by finished processes.
+	printf "Counting:  %d\r", $tot_counted
+                 if $opt_progress_rate;
+
+        foreach my $this_language ( keys %$part_result_by_language ) {
+            my $counts = $part_result_by_language->{$this_language};
+            foreach my $inner_key ( keys %$counts ) {
+                $Results_by_Language{$this_language}{$inner_key} += 
+                    $counts->{$inner_key};
             }
-            $Delta_by_Language{$Lang}{'code'   }{$status} += $code_count   ;
-            $Delta_by_Language{$Lang}{'blank'  }{$status} += $blank_count  ;
-            $Delta_by_Language{$Lang}{'comment'}{$status} += $comment_count;
-            $Delta_by_Language{$Lang}{'nFiles' }{$status} += 1             ;
-        }
-    }
-   #use Data::Dumper::Simple;
-   #use Data::Dumper;
-   #print Dumper(\@files_added, \@files_removed, \@file_pairs);
-    my @alignment = (); # only  used if --diff-alignment
-#print "after align_by_pairs:\n";
-
-#print "added:\n";
-    push @alignment, sprintf "Files added: %d\n", scalar @files_added
-        if $opt_diff_alignment;
-    foreach my $f (@files_added) {
-        next if $already_counted{$f};
-#printf "%10s -> %s\n", $f, $Language{$fh[$F+1]}{$f};
-        # Don't proceed unless the file (both L and R versions)
-        # is in a known language.
-        next if $opt_include_lang
-                and not $Include_Language{$Language{$fh[$F+1]}{$f}};
-        next if $Language{$fh[$F+1]}{$f} eq "(unknown)";
-        next if $Exclude_Language{$Language{$fh[$F+1]}{$f}};
-        push @alignment, sprintf "  + %s ; %s\n", $f, $Language{$fh[$F+1]}{$f}
-            if $opt_diff_alignment;
-        ++$Delta_by_Language{ $Language{$fh[$F+1]}{$f} }{'nFiles'}{'added'};
-        # Additionally, add contents of file $f to
-        #        Delta_by_File{$f}{comment/blank/code}{'added'}
-        #        Delta_by_Language{$lang}{comment/blank/code}{'added'}
-        my ($all_line_count,
-            $blank_count   ,
-            $comment_count ,
-           ) = call_counter($f, $Language{$fh[$F+1]}{$f}, \@Errors);
-        $Delta_by_Language{ $Language{$fh[$F+1]}{$f} }{'comment'}{'added'} +=
-            $comment_count;
-        $Delta_by_Language{ $Language{$fh[$F+1]}{$f} }{'blank'}{'added'}   +=
-            $blank_count;
-        $Delta_by_Language{ $Language{$fh[$F+1]}{$f} }{'code'}{'added'}    +=
-            $all_line_count - $blank_count - $comment_count;
-        $Delta_by_File{ $f }{'comment'}{'added'} = $comment_count;
-        $Delta_by_File{ $f }{'blank'}{'added'}   = $blank_count;
-        $Delta_by_File{ $f }{'code'}{'added'}    =
-            $all_line_count - $blank_count - $comment_count;
-    }
-    push @alignment, "\n";
-
-#print "removed:\n";
-    push @alignment, sprintf "Files removed: %d\n", scalar @files_removed
-        if $opt_diff_alignment;
-    foreach my $f (@files_removed) {
-        next if $already_counted{$f};
-        # Don't proceed unless the file (both L and R versions)
-        # is in a known language.
-        next if $opt_include_lang
-                and not $Include_Language{$Language{$fh[$F]}{$f}};
-        next if $Language{$fh[$F]}{$f} eq "(unknown)";
-        next if $Exclude_Language{$Language{$fh[$F]}{$f}};
-        ++$Delta_by_Language{ $Language{$fh[$F]}{$f} }{'nFiles'}{'removed'};
-        push @alignment, sprintf "  - %s ; %s\n", $f, $Language{$fh[$F]}{$f}
-            if $opt_diff_alignment;
-#printf "%10s -> %s\n", $f, $Language{$fh[$F  ]}{$f};
-        # Additionally, add contents of file $f to
-        #        Delta_by_File{$f}{comment/blank/code}{'removed'}
-        #        Delta_by_Language{$lang}{comment/blank/code}{'removed'}
-        my ($all_line_count,
-            $blank_count   ,
-            $comment_count ,
-           ) = call_counter($f, $Language{$fh[$F  ]}{$f}, \@Errors);
-        $Delta_by_Language{ $Language{$fh[$F  ]}{$f} }{'comment'}{'removed'} +=
-            $comment_count;
-        $Delta_by_Language{ $Language{$fh[$F  ]}{$f} }{'blank'}{'removed'}   +=
-            $blank_count;
-        $Delta_by_Language{ $Language{$fh[$F  ]}{$f} }{'code'}{'removed'}    +=
-            $all_line_count - $blank_count - $comment_count;
-        $Delta_by_File{ $f }{'comment'}{'removed'} = $comment_count;
-        $Delta_by_File{ $f }{'blank'}{'removed'}   = $blank_count;
-        $Delta_by_File{ $f }{'code'}{'removed'}    =
-            $all_line_count - $blank_count - $comment_count;
-    }
-    push @alignment, "\n";
-
-    my $alignment_pairs_index = scalar @alignment;
-    my $n_file_pairs_compared = 0;
-    # Don't know ahead of time how many file pairs will be compared
-    # since duplicates are weeded out below.  The answer is
-    # scalar @file_pairs only if there are no duplicates.
-    push @alignment, sprintf "File pairs compared: UPDATE_ME\n"
-        if $opt_diff_alignment;
-
-    foreach my $pair (@file_pairs) {
-        my $file_L = $pair->[0];
-        my $file_R = $pair->[1];
-        my $Lang_L = $Language{$fh[$F  ]}{$file_L};
-        my $Lang_R = $Language{$fh[$F+1]}{$file_R};
-#print "main step 6 file_L=$file_L    file_R=$file_R\n";
-        ++$nCounted;
-        printf "Counting:  %d\r", $nCounted
-            unless (!$opt_progress_rate or ($nCounted % $opt_progress_rate));
-        next if $Ignored{$file_L};
-        # filter out non-included languages
-        if ($opt_include_lang and not $Include_Language{$Lang_L}
-                              and not $Include_Language{$Lang_R}) {
-            $Ignored{$file_L} = "--include-lang=$Lang_L";
-            $Ignored{$file_R} = "--include-lang=$Lang_R";
-            next;
-        }
-        # filter out excluded or unrecognized languages
-        if ($Exclude_Language{$Lang_L} or $Exclude_Language{$Lang_R}) {
-            $Ignored{$file_L} = "--exclude-lang=$Lang_L";
-            $Ignored{$file_R} = "--exclude-lang=$Lang_R";
-            next;
-        }
-        my $not_Filters_by_Language_Lang_LR = 0;
-#print "file_LR = [$file_L] [$file_R]\n";
-#print "Lang_LR = [$Lang_L] [$Lang_R]\n";
-        if (!(@{$Filters_by_Language{$Lang_L} }) or
-            !(@{$Filters_by_Language{$Lang_R} })) {
-            $not_Filters_by_Language_Lang_LR = 1;
-        }
-        if ($not_Filters_by_Language_Lang_LR) {
-            if (($Lang_L eq "(unknown)") or ($Lang_R eq "(unknown)")) {
-                $Ignored{$fh[$F  ]}{$file_L} = "language unknown (#1)";
-                $Ignored{$fh[$F+1]}{$file_R} = "language unknown (#1)";
-            } else {
-                $Ignored{$fh[$F  ]}{$file_L} = "missing Filters_by_Language{$Lang_L}";
-                $Ignored{$fh[$F+1]}{$file_R} = "missing Filters_by_Language{$Lang_R}";
-            }
-            next;
         }
 
-#print "DIFF($file_L, $file_R)\n";
-        # step 0: compare the two files' contents
-        chomp ( my @lines_L = read_file($file_L) );
-        chomp ( my @lines_R = read_file($file_R) );
-        my $language_file_L = "";
-        if (defined $Language{$fh[$F]}{$file_L}) {
-            $language_file_L = $Language{$fh[$F]}{$file_L};
-        } else {
-            # files $file_L and $file_R do not contain known language
-            next;
-        }
-        my $contents_are_same = 1;
-        if (scalar @lines_L == scalar @lines_R) {
-            # same size, must compare line-by-line
-            for (my $i = 0; $i < scalar @lines_L; $i++) {
-                if ($lines_L[$i] ne $lines_R[$i]) {
-                    $contents_are_same = 0;
-                    last;
+        foreach my $this_language ( keys %$part_delta_by_language ) {
+            my $counts = $part_delta_by_language->{$this_language};
+            foreach my $inner_key ( keys %$counts ) {
+                my $statuses = $counts->{$inner_key};
+                foreach my $inner_status ( keys %$statuses ) {
+                    $Delta_by_Language{$this_language}{$inner_key}{$inner_status} += 
+                          $counts->{$inner_key}->{$inner_status};
                 }
             }
-            if ($contents_are_same) {
-                ++$Delta_by_Language{$language_file_L}{'nFiles'}{'same'};
-            } else {
-                ++$Delta_by_Language{$language_file_L}{'nFiles'}{'modified'};
-            }
-        } else {
-            $contents_are_same = 0;
-            # different sizes, contents have changed
-            ++$Delta_by_Language{$language_file_L}{'nFiles'}{'modified'};
         }
-        if ($opt_diff_alignment) {
-            my $str =  "$file_L | $file_R ; $language_file_L";
-            if ($contents_are_same) {
-                push @alignment, "  == $str";
-            } else {
-                push @alignment, "  != $str";
-            }
-            ++$n_file_pairs_compared;
-        }
+       
+        %Results_by_File = ( %Results_by_File, %$part_result_by_file );
+        %Delta_by_File = ( %Delta_by_File, %$part_delta_by_file );
+        %Ignored = (%Ignored, %$part_ignored );
+        push ( @alignment , @$part_alignment ); 
+        push ( @Errors, @$part_errors );
+    } );
 
-        # step 1: identify comments in both files
-#print "Diff blank removal L language= $Lang_L";
-#print " scalar(lines_L)=", scalar @lines_L, "\n";
-        my @original_minus_blanks_L
-                    = rm_blanks(  \@lines_L, $Lang_L, \%EOL_Continuation_re);
-#print "1: scalar(original_minus_blanks_L)=", scalar @original_minus_blanks_L, "\n";
-        @lines_L    = @original_minus_blanks_L;
-#print "2: scalar(lines_L)=", scalar @lines_L, "\n";
-        @lines_L    = add_newlines(\@lines_L); # compensate for rm_comments()
-        @lines_L    = rm_comments( \@lines_L, $Lang_L, $file_L,
-                                   \%EOL_Continuation_re, \@Errors);
-#print "3: scalar(lines_L)=", scalar @lines_L, "\n";
+    
+    my $num_filepairs_per_part = ceil ( ( scalar @file_pairs_tot ) / $num_processes );
+    my $num_filesremoved_per_part = ceil ( ( scalar @files_removed_tot ) / $num_processes );
+    my $num_filesadded_per_part = ceil ( ( scalar @files_added_tot ) / $num_processes );
 
-#print "Diff blank removal R language= $Lang_R\n";
-        my @original_minus_blanks_R
-                    = rm_blanks(  \@lines_R, $Lang_R, \%EOL_Continuation_re);
-        @lines_R    = @original_minus_blanks_R;
-        @lines_R    = add_newlines(\@lines_R); # taken away by rm_comments()
-        @lines_R    = rm_comments( \@lines_R, $Lang_R, $file_R,
-                                   \%EOL_Continuation_re, \@Errors);
-
-        my (@diff_LL, @diff_LR, );
-        array_diff( $file_L                  ,   # in
-                   \@original_minus_blanks_L ,   # in
-                   \@lines_L                 ,   # in
-                   "comment"                 ,   # in
-                   \@diff_LL, \@diff_LR      ,   # out
-                   \@Errors);                    # in/out
-
-        my (@diff_RL, @diff_RR, );
-        array_diff( $file_R                  ,   # in
-                   \@original_minus_blanks_R ,   # in
-                   \@lines_R                 ,   # in
-                   "comment"                 ,   # in
-                   \@diff_RL, \@diff_RR      ,   # out
-                   \@Errors);                    # in/out
-        # each line of each file is now classified as
-        # code or comment
-
-#use Data::Dumper;
-#print Dumper("diff_LL", \@diff_LL, "diff_LR", \@diff_LR, );
-#print Dumper("diff_RL", \@diff_RL, "diff_RR", \@diff_RR, );
-#die;
-        # step 2: separate code from comments for L and R files
-        my @code_L = ();
-        my @code_R = ();
-        my @comm_L = ();
-        my @comm_R = ();
-        foreach my $line_info (@diff_LL) {
-            if      ($line_info->{'type'} eq "code"   ) {
-                push @code_L, $line_info->{char};
-            } elsif ($line_info->{'type'} eq "comment") {
-                push @comm_L, $line_info->{char};
-            } else {
-                die "Diff unexpected line type ",
-                    $line_info->{'type'}, "for $file_L line ",
-                    $line_info->{'lnum'};
-            }
-        }
-        foreach my $line_info (@diff_RL) {
-            if      ($line_info->{type} eq "code"   ) {
-                push @code_R, $line_info->{'char'};
-            } elsif ($line_info->{type} eq "comment") {
-                push @comm_R, $line_info->{'char'};
-            } else {
-                die "Diff unexpected line type ",
-                    $line_info->{'type'}, "for $file_R line ",
-                    $line_info->{'lnum'};
-            }
+    while ( 1 ) { 
+        my @files_added_part = splice @files_added_tot, 0, $num_filesadded_per_part;
+        my @files_removed_part = splice @files_removed_tot, 0, $num_filesremoved_per_part;
+        my @filepairs_part = splice @file_pairs_tot, 0, $num_filepairs_per_part;
+        if ( scalar @files_added_part == 0 and scalar @files_removed_part == 0 and
+             scalar @filepairs_part == 0 ) {
+            last;
         }
 
-        if ($opt_ignore_whitespace) {
-            # strip all whitespace from each line of source code
-            # and comments then use these stripped arrays in diffs
-            foreach (@code_L) { s/\s+//g }
-            foreach (@code_R) { s/\s+//g }
-            foreach (@comm_L) { s/\s+//g }
-            foreach (@comm_R) { s/\s+//g }
-        }
-        if ($opt_ignore_case) {
-            # change all text to lowercase in diffs
-            foreach (@code_L) { $_ = lc }
-            foreach (@code_R) { $_ = lc }
-            foreach (@comm_L) { $_ = lc }
-            foreach (@comm_R) { $_ = lc }
-        }
-        # step 3: compute code diffs
-        array_diff("$file_L v. $file_R"   ,   # in
-                   \@code_L               ,   # in
-                   \@code_R               ,   # in
-                   "revision"             ,   # in
-                   \@diff_LL, \@diff_LR   ,   # out
-                   \@Errors);                 # in/out
-#print Dumper("diff_LL", \@diff_LL, "diff_LR", \@diff_LR, );
-#print Dumper("diff_LR", \@diff_LR);
-        foreach my $line_info (@diff_LR) {
-            my $status = $line_info->{'desc'}; # same|added|removed|modified
-            ++$Delta_by_Language{$Lang_L}{'code'}{$status};
-            if ($opt_by_file) {
-                ++$Delta_by_File{$file_L}{'code'}{$status};
-            }
-        }
-#use Data::Dumper;
-#print Dumper("code diffs:", \@diff_LL, \@diff_LR);
-
-        # step 4: compute comment diffs
-        array_diff("$file_L v. $file_R"   ,   # in
-                   \@comm_L               ,   # in
-                   \@comm_R               ,   # in
-                   "revision"             ,   # in
-                   \@diff_LL, \@diff_LR   ,   # out
-                   \@Errors);                 # in/out
-#print Dumper("comment diff_LR", \@diff_LR);
-        foreach my $line_info (@diff_LR) {
-            my $status = $line_info->{'desc'}; # same|added|removed|modified
-            ++$Delta_by_Language{$Lang_L}{'comment'}{$status};
-            if ($opt_by_file) {
-                ++$Delta_by_File{$file_L}{'comment'}{$status};
-            }
-        }
-#print Dumper("comment diffs:", \@diff_LL, \@diff_LR);
-
-        # step 5: compute difference in blank lines (kind of pointless)
-        next if $Lang_L eq '(unknown)' or
-                $Lang_R eq '(unknown)';
-        my ($all_line_count_L,
-            $blank_count_L   ,
-            $comment_count_L ,
-           ) = call_counter($file_L, $Lang_L, \@Errors);
-
-        my ($all_line_count_R,
-            $blank_count_R   ,
-            $comment_count_R ,
-           ) = call_counter($file_R, $Lang_R, \@Errors);
-
-        if ($blank_count_L <  $blank_count_R) {
-            my $D = $blank_count_R - $blank_count_L;
-            $Delta_by_Language{$Lang_L}{'blank'}{'added'}   += $D;
-        } else {
-            my $D = $blank_count_L - $blank_count_R;
-            $Delta_by_Language{$Lang_L}{'blank'}{'removed'} += $D;
-        }
-        if ($opt_by_file) {
-            if ($blank_count_L <  $blank_count_R) {
-                my $D = $blank_count_R - $blank_count_L;
-                $Delta_by_File{$file_L}{'blank'}{'added'}   += $D;
-            } else {
-                my $D = $blank_count_L - $blank_count_R;
-                $Delta_by_File{$file_L}{'blank'}{'removed'} += $D;
-            }
-        }
-
-        my $code_count_L = $all_line_count_L-$blank_count_L-$comment_count_L;
-        if ($opt_by_file) {
-            $Results_by_File{$file_L}{'code'   } = $code_count_L    ;
-            $Results_by_File{$file_L}{'blank'  } = $blank_count_L   ;
-            $Results_by_File{$file_L}{'comment'} = $comment_count_L ;
-            $Results_by_File{$file_L}{'lang'   } = $Lang_L          ;
-            $Results_by_File{$file_L}{'nFiles' } = 1                ;
-        } else {
-            $Results_by_File{$file_L} = 1;  # just keep track of counted files
-        }
-
-        $Results_by_Language{$Lang_L}{'nFiles'}++;
-        $Results_by_Language{$Lang_L}{'code'}    += $code_count_L   ;
-        $Results_by_Language{$Lang_L}{'blank'}   += $blank_count_L  ;
-        $Results_by_Language{$Lang_L}{'comment'} += $comment_count_L;
+        $pm->start() and next;
+        my $count_result = count_filesets ( $fset_a, $fset_b,  
+            \@files_added_part, \@files_removed_part, \@filepairs_part, 1, \%Language );
+        $pm->finish(0 , $count_result);
     }
-    if ($opt_diff_alignment) {
-        $alignment[$alignment_pairs_index] =~ s/UPDATE_ME/$n_file_pairs_compared/;
-        write_file($opt_diff_alignment, @alignment);
-    }
-
+    # Wait for processes to finish
+    $pm->wait_all_children();
 }
+
+# Write alignment data, if needed
+if ($opt_diff_alignment) {
+    push (@alignment, "File pairs compared: " . $n_filepairs_compared . "\n");
+    write_file($opt_diff_alignment, @alignment);
+}
+
 #use Data::Dumper;
 #print Dumper("Delta_by_Language:"  , \%Delta_by_Language);
 #print Dumper("Results_by_Language:", \%Results_by_Language);
@@ -2065,6 +1800,402 @@ sub count_files {
         "errors"  => \@p_errors,
         "results_by_file" => \%p_rbf,
         "results_by_language" => \%p_rbl,
+    }
+}
+sub count_filesets {
+    my ($fset_a,$fset_b,$files_added,$files_removed,$file_pairs,$counter_type,$language_hash) = @_;
+    my @p_errors = ();
+    my @p_alignment = ();
+    my %p_ignored = ();
+    my %p_rbl = ();
+    my %p_rbf = ();
+    my %p_dbl = ();
+    my %p_dbf = ();
+    my %Language = %$language_hash;
+
+        my $nCounted = 0;
+
+    
+        my %already_counted = (); # already_counted{ filename } = 1
+
+        if (!@$file_pairs) {
+            # Special case where all files were either added or deleted.
+            # In this case, one of these arrays will be empty:
+            #   @files_added, @files_removed
+            # so loop over both to cover both cases.
+            my $status = @$files_added ? 'added' : 'removed';
+            my $fset = @$files_added ? $fset_b : $fset_a;
+            foreach my $file (@$files_added, @$files_removed) {
+                next unless defined $Language{$fset}{$file};
+                my $Lang = $Language{$fset}{$file};
+                next if $Lang eq '(unknown)';
+                my ($all_line_count,
+                    $blank_count   ,
+                    $comment_count ,
+                   ) = call_counter($file, $Lang, \@p_errors);
+                $already_counted{$file} = 1;
+                my $code_count = $all_line_count-$blank_count-$comment_count;
+                if ($opt_by_file) {
+                    $p_dbf{$file}{'code'   }{$status} += $code_count   ;
+                    $p_dbf{$file}{'blank'  }{$status} += $blank_count  ;
+                    $p_dbf{$file}{'comment'}{$status} += $comment_count;
+                    $p_dbf{$file}{'lang'   }{$status}  = $Lang         ;
+                    $p_dbf{$file}{'nFiles' }{$status} += 1             ;
+                }
+                $p_dbl{$Lang}{'code'   }{$status} += $code_count   ;
+                $p_dbl{$Lang}{'blank'  }{$status} += $blank_count  ;
+                $p_dbl{$Lang}{'comment'}{$status} += $comment_count;
+                $p_dbl{$Lang}{'nFiles' }{$status} += 1             ;
+            }
+        }
+
+        #use Data::Dumper::Simple;
+        #use Data::Dumper;
+        #print Dumper(\@files_added, \@files_removed, \@file_pairs);
+        #print "after align_by_pairs:\n";
+        #print "added:\n";
+        push @p_alignment, sprintf "Files added: %d\n", scalar @$files_added
+            if $opt_diff_alignment;
+
+        foreach my $f (@$files_added) {
+            next if $already_counted{$f};
+            #printf "%10s -> %s\n", $f, $Language{$fh[$F+1]}{$f};
+            # Don't proceed unless the file (both L and R versions)
+            # is in a known language.
+            next if $opt_include_lang
+                and not $Include_Language{$Language{$fset_b}{$f}};
+            next if $Language{$fset_b}{$f} eq "(unknown)";
+            next if $Exclude_Language{$fset_b}{$f};
+            push @p_alignment, sprintf "  + %s ; %s\n", $f, $Language{$fset_b}{$f}
+            		if $opt_diff_alignment;
+            ++$p_dbl{ $Language{$fset_b}{$f} }{'nFiles'}{'added'};
+            # Additionally, add contents of file $f to
+            # Delta_by_File{$f}{comment/blank/code}{'added'}
+            # Delta_by_Language{$lang}{comment/blank/code}{'added'}
+            # via the $p_dbl and $p_dbf variables.
+            my ($all_line_count,
+                $blank_count   ,
+                $comment_count ,
+               ) = call_counter($f, $Language{$fset_b}{$f}, \@p_errors);
+            $p_dbl{ $Language{$fset_b}{$f} }{'comment'}{'added'} +=
+               $comment_count;
+            $p_dbl{ $Language{$fset_b}{$f} }{'blank'}{'added'}   +=
+               $blank_count;
+            $p_dbl{ $Language{$fset_b}{$f} }{'code'}{'added'}    +=
+               $all_line_count - $blank_count - $comment_count;
+            $p_dbf{ $f }{'comment'}{'added'} = $comment_count;
+            $p_dbf{ $f }{'blank'}{'added'}   = $blank_count;
+            $p_dbf{ $f }{'code'}{'added'}    =
+               $all_line_count - $blank_count - $comment_count;
+        }
+
+        push @p_alignment, "\n";
+
+        #print "removed:\n";
+        push @p_alignment, sprintf "Files removed: %d\n", scalar @$files_removed
+            if $opt_diff_alignment;
+        foreach my $f (@$files_removed) {
+            next if $already_counted{$f};
+            # Don't proceed unless the file (both L and R versions)
+            # is in a known language.
+            next if $opt_include_lang
+                and not $Include_Language{$Language{$fset_a}{$f}};
+            next if $Language{$fset_a}{$f} eq "(unknown)";
+            next if $Exclude_Language{$fset_a}{$f};
+            ++$p_dbl{ $Language{$fset_a}{$f} }{'nFiles'}{'removed'};
+            push @p_alignment, sprintf "  - %s ; %s\n", $f, $Language{$fset_a}{$f}
+                if $opt_diff_alignment;
+            #printf "%10s -> %s\n", $f, $Language{$fh[$F  ]}{$f};
+            # Additionally, add contents of file $f to
+            #        Delta_by_File{$f}{comment/blank/code}{'removed'}
+            #        Delta_by_Language{$lang}{comment/blank/code}{'removed'}
+            # via the $p_dbl and $p_dbf variables.
+            my ($all_line_count,
+                $blank_count   ,
+                $comment_count ,
+               ) = call_counter($f, $Language{$fset_a}{$f}, \@p_errors);
+            $p_dbl{ $Language{$fset_a}{$f}}{'comment'}{'removed'} +=
+                 $comment_count;
+            $p_dbl{ $Language{$fset_a}{$f}}{'blank'}{'removed'}   +=
+                 $blank_count;
+            $p_dbl{ $Language{$fset_a}{$f}}{'code'}{'removed'}    +=
+                 $all_line_count - $blank_count - $comment_count;
+            $p_dbf{ $f }{'comment'}{'removed'} = $comment_count;
+            $p_dbf{ $f }{'blank'}{'removed'}   = $blank_count;
+            $p_dbf{ $f }{'code'}{'removed'}    =
+                $all_line_count - $blank_count - $comment_count;
+        }
+        push @p_alignment, "\n";
+
+         my $n_file_pairs_compared = 0;
+        # Don't know ahead of time how many file pairs will be compared
+        # since duplicates are weeded out below.  The answer is
+        # scalar @file_pairs only if there are no duplicates.
+ 
+        foreach my $pair (@$file_pairs) {
+            my $file_L = $pair->[0];
+            my $file_R = $pair->[1];
+            my $Lang_L = $Language{$fset_a}{$file_L};
+            my $Lang_R = $Language{$fset_b}{$file_R};
+            #print "main step 6 file_L=$file_L    file_R=$file_R\n";
+            ++$nCounted;
+            printf "Counting:  %d\r", $nCounted
+                unless ($counter_type or !$opt_progress_rate or ($nCounted % $opt_progress_rate));
+            next if $p_ignored{$file_L};
+            # filter out non-included languages
+            if ($opt_include_lang and not $Include_Language{$Lang_L}
+                              and not $Include_Language{$Lang_R}) {
+                $p_ignored{$file_L} = "--include-lang=$Lang_L";
+                $p_ignored{$file_R} = "--include-lang=$Lang_R";
+                next;
+            }
+            # filter out excluded or unrecognized languages
+            if ($Exclude_Language{$Lang_L} or $Exclude_Language{$Lang_R}) {
+                $p_ignored{$file_L} = "--exclude-lang=$Lang_L";
+                $p_ignored{$file_R} = "--exclude-lang=$Lang_R";
+                next;
+            }
+
+            my $not_Filters_by_Language_Lang_LR = 0;
+            #print "file_LR = [$file_L] [$file_R]\n";
+            #print "Lang_LR = [$Lang_L] [$Lang_R]\n";
+            if (!(@{$Filters_by_Language{$Lang_L} }) or
+                !(@{$Filters_by_Language{$Lang_R} })) {
+                $not_Filters_by_Language_Lang_LR = 1;
+            }
+            if ($not_Filters_by_Language_Lang_LR) {
+                if (($Lang_L eq "(unknown)") or ($Lang_R eq "(unknown)")) {
+                    $p_ignored{$fset_a}{$file_L} = "language unknown (#1)";
+                    $p_ignored{$fset_b}{$file_R} = "language unknown (#1)";
+                } else {
+                    $p_ignored{$fset_a}{$file_L} = "missing Filters_by_Language{$Lang_L}";
+                    $p_ignored{$fset_b}{$file_R} = "missing Filters_by_Language{$Lang_R}";
+                }
+                next;
+            }
+
+            #print "DIFF($file_L, $file_R)\n";
+            # step 0: compare the two files' contents
+            chomp ( my @lines_L = read_file($file_L) );
+            chomp ( my @lines_R = read_file($file_R) );
+            my $language_file_L = "";
+            if (defined $Language{$fset_a}{$file_L}) {
+                $language_file_L = $Language{$fset_a}{$file_L};
+            } else {
+                # files $file_L and $file_R do not contain known language
+                next;
+            }
+
+            my $contents_are_same = 1;
+            if (scalar @lines_L == scalar @lines_R) {
+                # same size, must compare line-by-line
+                for (my $i = 0; $i < scalar @lines_L; $i++) {
+                    if ($lines_L[$i] ne $lines_R[$i]) {
+                        $contents_are_same = 0;
+                        last;
+                    }
+                }
+                if ($contents_are_same) {
+                    ++$p_dbl{$language_file_L}{'nFiles'}{'same'};
+                } else {
+                    ++$p_dbl{$language_file_L}{'nFiles'}{'modified'};
+                }
+            } else {
+                $contents_are_same = 0;
+                # different sizes, contents have changed
+                ++$p_dbl{$language_file_L}{'nFiles'}{'modified'};
+            }
+
+            if ($opt_diff_alignment) {
+                my $str =  "$file_L | $file_R ; $language_file_L";
+                if ($contents_are_same) {
+                    push @p_alignment, "  == $str";
+                } else {
+                    push @p_alignment, "  != $str";
+                }
+                ++$n_file_pairs_compared;
+            }
+
+            # step 1: identify comments in both files
+            #print "Diff blank removal L language= $Lang_L";
+            #print " scalar(lines_L)=", scalar @lines_L, "\n";
+            my @original_minus_blanks_L
+                    = rm_blanks(  \@lines_L, $Lang_L, \%EOL_Continuation_re);
+            #print "1: scalar(original_minus_blanks_L)=", scalar @original_minus_blanks_L, "\n";
+            @lines_L    = @original_minus_blanks_L;
+            #print "2: scalar(lines_L)=", scalar @lines_L, "\n";
+            @lines_L    = add_newlines(\@lines_L); # compensate for rm_comments()
+            @lines_L    = rm_comments( \@lines_L, $Lang_L, $file_L,
+                                   \%EOL_Continuation_re);
+            #print "3: scalar(lines_L)=", scalar @lines_L, "\n";
+
+            #print "Diff blank removal R language= $Lang_R\n";
+            my @original_minus_blanks_R
+                    = rm_blanks(  \@lines_R, $Lang_R, \%EOL_Continuation_re);
+            @lines_R    = @original_minus_blanks_R;
+            @lines_R    = add_newlines(\@lines_R); # taken away by rm_comments()
+            @lines_R    = rm_comments( \@lines_R, $Lang_R, $file_R,
+                                   \%EOL_Continuation_re);
+
+            my (@diff_LL, @diff_LR, );
+                array_diff( $file_L                  ,   # in
+                   \@original_minus_blanks_L ,   # in
+                   \@lines_L                 ,   # in
+                   "comment"                 ,   # in
+                   \@diff_LL, \@diff_LR      ,   # out
+                   \@p_errors);                    # in/out
+
+            my (@diff_RL, @diff_RR, );
+                array_diff( $file_R                  ,   # in
+                   \@original_minus_blanks_R ,   # in
+                   \@lines_R                 ,   # in
+                   "comment"                 ,   # in
+                   \@diff_RL, \@diff_RR      ,   # out
+                   \@p_errors);                    # in/out
+            # each line of each file is now classified as
+            # code or comment
+
+            #use Data::Dumper;
+            #print Dumper("diff_LL", \@diff_LL, "diff_LR", \@diff_LR, );
+            #print Dumper("diff_RL", \@diff_RL, "diff_RR", \@diff_RR, );
+            #die;
+
+            # step 2: separate code from comments for L and R files
+            my @code_L = ();
+            my @code_R = ();
+            my @comm_L = ();
+            my @comm_R = ();
+            foreach my $line_info (@diff_LL) {
+                if      ($line_info->{'type'} eq "code"   ) {
+                    push @code_L, $line_info->{char};
+                } elsif ($line_info->{'type'} eq "comment") {
+                    push @comm_L, $line_info->{char};
+                } else {
+                    die "Diff unexpected line type ",
+                        $line_info->{'type'}, "for $file_L line ",
+                        $line_info->{'lnum'};
+                }
+            }
+
+            foreach my $line_info (@diff_RL) {
+                if      ($line_info->{type} eq "code"   ) {
+                    push @code_R, $line_info->{'char'};
+                } elsif ($line_info->{type} eq "comment") {
+                    push @comm_R, $line_info->{'char'};
+                } else {
+                    die "Diff unexpected line type ",
+                        $line_info->{'type'}, "for $file_R line ",
+                        $line_info->{'lnum'};
+                }
+            }
+
+        if ($opt_ignore_whitespace) {
+            # strip all whitespace from each line of source code
+            # and comments then use these stripped arrays in diffs
+            foreach (@code_L) { s/\s+//g }
+            foreach (@code_R) { s/\s+//g }
+            foreach (@comm_L) { s/\s+//g }
+            foreach (@comm_R) { s/\s+//g }
+        }
+        if ($opt_ignore_case) {
+            # change all text to lowercase in diffs
+            foreach (@code_L) { $_ = lc }
+            foreach (@code_R) { $_ = lc }
+            foreach (@comm_L) { $_ = lc }
+            foreach (@comm_R) { $_ = lc }
+        }
+        # step 3: compute code diffs
+        array_diff("$file_L v. $file_R"   ,   # in
+                   \@code_L               ,   # in
+                   \@code_R               ,   # in
+                   "revision"             ,   # in
+                   \@diff_LL, \@diff_LR   ,   # out
+                   \@p_errors);                 # in/out
+        #print Dumper("diff_LL", \@diff_LL, "diff_LR", \@diff_LR, );
+        #print Dumper("diff_LR", \@diff_LR);
+        foreach my $line_info (@diff_LR) {
+            my $status = $line_info->{'desc'}; # same|added|removed|modified
+            ++$p_dbl{$Lang_L}{'code'}{$status};
+            if ($opt_by_file) {
+                ++$p_dbf{$file_L}{'code'}{$status};
+            }
+        }
+        #use Data::Dumper;
+        #print Dumper("code diffs:", \@diff_LL, \@diff_LR);
+
+        # step 4: compute comment diffs
+        array_diff("$file_L v. $file_R"   ,   # in
+                   \@comm_L               ,   # in
+                   \@comm_R               ,   # in
+                   "revision"             ,   # in
+                   \@diff_LL, \@diff_LR   ,   # out
+                   \@Errors);                 # in/out
+        #print Dumper("comment diff_LR", \@diff_LR);
+        foreach my $line_info (@diff_LR) {
+            my $status = $line_info->{'desc'}; # same|added|removed|modified
+            ++$p_dbl{$Lang_L}{'comment'}{$status};
+            if ($opt_by_file) {
+                ++$p_dbf{$file_L}{'comment'}{$status};
+            }
+        }
+        #print Dumper("comment diffs:", \@diff_LL, \@diff_LR);
+
+        # step 5: compute difference in blank lines (kind of pointless)
+        next if $Lang_L eq '(unknown)' or
+                $Lang_R eq '(unknown)';
+        my ($all_line_count_L,
+            $blank_count_L   ,
+            $comment_count_L ,
+           ) = call_counter($file_L, $Lang_L, \@Errors);
+
+        my ($all_line_count_R,
+            $blank_count_R   ,
+            $comment_count_R ,
+           ) = call_counter($file_R, $Lang_R, \@Errors);
+
+        if ($blank_count_L <  $blank_count_R) {
+            my $D = $blank_count_R - $blank_count_L;
+            $p_dbl{$Lang_L}{'blank'}{'added'}   += $D;
+        } else {
+            my $D = $blank_count_L - $blank_count_R;
+            $p_dbl{$Lang_L}{'blank'}{'removed'} += $D;
+        }
+        if ($opt_by_file) {
+            if ($blank_count_L <  $blank_count_R) {
+                my $D = $blank_count_R - $blank_count_L;
+                $p_dbf{$file_L}{'blank'}{'added'}   += $D;
+            } else {
+                my $D = $blank_count_L - $blank_count_R;
+                $p_dbf{$file_L}{'blank'}{'removed'} += $D;
+            }
+        }
+
+        my $code_count_L = $all_line_count_L-$blank_count_L-$comment_count_L;
+        if ($opt_by_file) {
+            $p_rbf{$file_L}{'code'   } = $code_count_L    ;
+            $p_rbf{$file_L}{'blank'  } = $blank_count_L   ;
+            $p_rbf{$file_L}{'comment'} = $comment_count_L ;
+            $p_rbf{$file_L}{'lang'   } = $Lang_L          ;
+            $p_rbf{$file_L}{'nFiles' } = 1                ;
+        } else {
+            $p_rbf{$file_L} = 1;  # just keep track of counted files
+        }
+
+        $p_rbl{$Lang_L}{'nFiles'}++;
+        $p_rbl{$Lang_L}{'code'}    += $code_count_L   ;
+        $p_rbl{$Lang_L}{'blank'}   += $blank_count_L  ;
+        $p_rbl{$Lang_L}{'comment'} += $comment_count_L;
+    }
+
+    return {
+        "ignored" => \%p_ignored,
+        "errors"  => \@p_errors,
+        "results_by_file" => \%p_rbf,
+        "results_by_language" => \%p_rbl,
+        "delta_by_file" => \%p_dbf,
+        "delta_by_language" => \%p_dbl,
+        "alignment" => \@p_alignment,
+        "n_filepairs_compared" => $n_file_pairs_compared
     }
 }
 sub exclude_dir_validates {                  # {{{1

--- a/cloc
+++ b/cloc
@@ -1340,7 +1340,7 @@ my %Delta_by_File       = ();
 my @files_added_tot = ();
 my @files_removed_tot = ();
 my @file_pairs_tot = ();
-my @alignment = ();
+my %alignment = ();
 
 my $fset_a = $fh[0];
 my $fset_b = $fh[1];
@@ -1369,7 +1369,7 @@ if ( $max_processes == 0) {
     %Delta_by_File = %{$part->{'delta_by_file'}};
     %Delta_by_Language= %{$part->{'delta_by_language'}};
     %Ignored = ( %Ignored, %{$part->{'ignored'}});
-    @alignment = @{$part->{'alignment'}};
+    %alignment = %{$part->{'alignment'}};
     $n_filepairs_compared = $part->{'n_filepairs_compared'};
     push ( @Errors, @{$part->{'errors'}});   
 }
@@ -1423,7 +1423,7 @@ else {
         %Results_by_File = ( %Results_by_File, %$part_result_by_file );
         %Delta_by_File = ( %Delta_by_File, %$part_delta_by_file );
         %Ignored = (%Ignored, %$part_ignored );
-        push ( @alignment , @$part_alignment ); 
+        %alignment = ( %alignment, %$part_alignment );
         push ( @Errors, @$part_errors );
     } );
 
@@ -1452,8 +1452,7 @@ else {
 
 # Write alignment data, if needed
 if ($opt_diff_alignment) {
-    push (@alignment, "File pairs compared: " . $n_filepairs_compared . "\n");
-    write_file($opt_diff_alignment, @alignment);
+    write_alignment_data ( $opt_diff_alignment, $n_filepairs_compared, \%alignment ) ; 
 }
 
 #use Data::Dumper;
@@ -1805,7 +1804,7 @@ sub count_files {
 sub count_filesets {
     my ($fset_a,$fset_b,$files_added,$files_removed,$file_pairs,$counter_type,$language_hash) = @_;
     my @p_errors = ();
-    my @p_alignment = ();
+    my %p_alignment = ();
     my %p_ignored = ();
     my %p_rbl = ();
     my %p_rbf = ();
@@ -1853,8 +1852,6 @@ sub count_filesets {
     #print Dumper(\@files_added, \@files_removed, \@file_pairs);
     #print "after align_by_pairs:\n";
     #print "added:\n";
-    push @p_alignment, sprintf "Files added: %d\n", scalar @$files_added
-        if $opt_diff_alignment;
 
     foreach my $f (@$files_added) {
         next if $already_counted{$f};
@@ -1865,8 +1862,7 @@ sub count_filesets {
             and not $Include_Language{$Language{$fset_b}{$f}};
         next if $Language{$fset_b}{$f} eq "(unknown)";
         next if $Exclude_Language{$fset_b}{$f};
-        push @p_alignment, sprintf "  + %s ; %s\n", $f, $Language{$fset_b}{$f}
-    		if $opt_diff_alignment;
+        $p_alignment{"added"}{sprintf "  + %s ; %s\n", $f, $Language{$fset_b}{$f}} = 1;
         ++$p_dbl{ $Language{$fset_b}{$f} }{'nFiles'}{'added'};
         # Additionally, add contents of file $f to
         # Delta_by_File{$f}{comment/blank/code}{'added'}
@@ -1888,11 +1884,7 @@ sub count_filesets {
            $all_line_count - $blank_count - $comment_count;
     }
 
-    push @p_alignment, "\n";
-
     #print "removed:\n";
-    push @p_alignment, sprintf "Files removed: %d\n", scalar @$files_removed
-        if $opt_diff_alignment;
     foreach my $f (@$files_removed) {
         next if $already_counted{$f};
         # Don't proceed unless the file (both L and R versions)
@@ -1902,8 +1894,7 @@ sub count_filesets {
         next if $Language{$fset_a}{$f} eq "(unknown)";
         next if $Exclude_Language{$fset_a}{$f};
         ++$p_dbl{ $Language{$fset_a}{$f} }{'nFiles'}{'removed'};
-        push @p_alignment, sprintf "  - %s ; %s\n", $f, $Language{$fset_a}{$f}
-            if $opt_diff_alignment;
+        $p_alignment{"removed"}{sprintf "  - %s ; %s\n", $f, $Language{$fset_a}{$f}} = 1;
         #printf "%10s -> %s\n", $f, $Language{$fh[$F  ]}{$f};
         # Additionally, add contents of file $f to
         #        Delta_by_File{$f}{comment/blank/code}{'removed'}
@@ -1925,8 +1916,6 @@ sub count_filesets {
             $all_line_count - $blank_count - $comment_count;
     }
     
-    push @p_alignment, "\n";
-
     my $n_file_pairs_compared = 0;
     # Don't know ahead of time how many file pairs will be compared
     # since duplicates are weeded out below.  The answer is
@@ -2009,9 +1998,9 @@ sub count_filesets {
         if ($opt_diff_alignment) {
             my $str =  "$file_L | $file_R ; $language_file_L";
             if ($contents_are_same) {
-                push @p_alignment, "  == $str";
+                $p_alignment{"pairs"}{"  == $str"} = 1;
             } else {
-                push @p_alignment, "  != $str";
+                $p_alignment{"pairs"}{"  != $str"} = 1;                
             }
             ++$n_file_pairs_compared;
         }
@@ -2193,9 +2182,37 @@ sub count_filesets {
         "results_by_language" => \%p_rbl,
         "delta_by_file" => \%p_dbf,
         "delta_by_language" => \%p_dbl,
-        "alignment" => \@p_alignment,
+        "alignment" => \%p_alignment,
         "n_filepairs_compared" => $n_file_pairs_compared
     }
+}
+sub write_alignment_data {
+    my ($filename, $n_filepairs_compared, $data ) = @_;
+    my @output = ();
+    if ( $data->{'added'} ) {
+        my %added_lines = %{$data->{'added'}};
+        push (@output, "Files added: " . (scalar keys %added_lines) . "\n");
+        foreach my $line ( sort keys %added_lines ) {
+            push (@output, $line);
+        }
+        push (@output, "\n" );
+    }
+    if ( $data->{'removed'} ) {
+        my %removed_lines = %{$data->{'removed'}};
+        push (@output, "Files removed: " . (scalar keys %removed_lines) . "\n");
+        foreach my $line ( sort keys %removed_lines ) {
+            push (@output, $line);
+        }
+        push (@output, "\n");
+    }
+    if ( $data->{'pairs'} ) {
+        my %pairs = %{$data->{'pairs'}};
+        push (@output, "File pairs compared: " . $n_filepairs_compared . "\n");
+        foreach my $pair ( sort keys %pairs ) {
+            push (@output, $pair);
+        }
+    }
+    write_file($filename, @output);
 }
 sub exclude_dir_validates {                  # {{{1
     my ($rh_Exclude_Dir) = @_;

--- a/cloc
+++ b/cloc
@@ -1443,7 +1443,7 @@ else {
 
         $pm->start() and next;
         my $count_result = count_filesets ( $fset_a, $fset_b,  
-            \@files_added_part, \@files_removed_part, \@filepairs_part, 1, \%Language );
+            \@files_added_part, \@files_removed_part, \@filepairs_part, 1 , \%Language );
         $pm->finish(0 , $count_result);
     }
     # Wait for processes to finish
@@ -1813,281 +1813,280 @@ sub count_filesets {
     my %p_dbf = ();
     my %Language = %$language_hash;
 
-        my $nCounted = 0;
+    my $nCounted = 0;
+  
+    my %already_counted = (); # already_counted{ filename } = 1
 
+    if (!@$file_pairs) {
+        # Special case where all files were either added or deleted.
+        # In this case, one of these arrays will be empty:
+        #   @files_added, @files_removed
+        # so loop over both to cover both cases.
+        my $status = @$files_added ? 'added' : 'removed';
+        my $fset = @$files_added ? $fset_b : $fset_a;
+        foreach my $file (@$files_added, @$files_removed) {
+            next unless defined $Language{$fset}{$file};
+            my $Lang = $Language{$fset}{$file};
+            next if $Lang eq '(unknown)';
+            my ($all_line_count,
+                $blank_count   ,
+                $comment_count ,
+                ) = call_counter($file, $Lang, \@p_errors);
+            $already_counted{$file} = 1;
+            my $code_count = $all_line_count-$blank_count-$comment_count;
+            if ($opt_by_file) {
+                $p_dbf{$file}{'code'   }{$status} += $code_count   ;
+                $p_dbf{$file}{'blank'  }{$status} += $blank_count  ;
+                $p_dbf{$file}{'comment'}{$status} += $comment_count;
+                $p_dbf{$file}{'lang'   }{$status}  = $Lang         ;
+                $p_dbf{$file}{'nFiles' }{$status} += 1             ;
+            }
+            $p_dbl{$Lang}{'code'   }{$status} += $code_count   ;
+            $p_dbl{$Lang}{'blank'  }{$status} += $blank_count  ;
+            $p_dbl{$Lang}{'comment'}{$status} += $comment_count;
+            $p_dbl{$Lang}{'nFiles' }{$status} += 1             ;
+        }
+    }
+
+    #use Data::Dumper::Simple;
+    #use Data::Dumper;
+    #print Dumper(\@files_added, \@files_removed, \@file_pairs);
+    #print "after align_by_pairs:\n";
+    #print "added:\n";
+    push @p_alignment, sprintf "Files added: %d\n", scalar @$files_added
+        if $opt_diff_alignment;
+
+    foreach my $f (@$files_added) {
+        next if $already_counted{$f};
+        #printf "%10s -> %s\n", $f, $Language{$fh[$F+1]}{$f};
+        # Don't proceed unless the file (both L and R versions)
+        # is in a known language.
+        next if $opt_include_lang
+            and not $Include_Language{$Language{$fset_b}{$f}};
+        next if $Language{$fset_b}{$f} eq "(unknown)";
+        next if $Exclude_Language{$fset_b}{$f};
+        push @p_alignment, sprintf "  + %s ; %s\n", $f, $Language{$fset_b}{$f}
+    		if $opt_diff_alignment;
+        ++$p_dbl{ $Language{$fset_b}{$f} }{'nFiles'}{'added'};
+        # Additionally, add contents of file $f to
+        # Delta_by_File{$f}{comment/blank/code}{'added'}
+        # Delta_by_Language{$lang}{comment/blank/code}{'added'}
+        # via the $p_dbl and $p_dbf variables.
+        my ($all_line_count,
+            $blank_count   ,
+            $comment_count ,
+           ) = call_counter($f, $Language{$fset_b}{$f}, \@p_errors);
+        $p_dbl{ $Language{$fset_b}{$f} }{'comment'}{'added'} +=
+           $comment_count;
+        $p_dbl{ $Language{$fset_b}{$f} }{'blank'}{'added'}   +=
+           $blank_count;
+        $p_dbl{ $Language{$fset_b}{$f} }{'code'}{'added'}    +=
+           $all_line_count - $blank_count - $comment_count;
+        $p_dbf{ $f }{'comment'}{'added'} = $comment_count;
+        $p_dbf{ $f }{'blank'}{'added'}   = $blank_count;
+        $p_dbf{ $f }{'code'}{'added'}    =
+           $all_line_count - $blank_count - $comment_count;
+    }
+
+    push @p_alignment, "\n";
+
+    #print "removed:\n";
+    push @p_alignment, sprintf "Files removed: %d\n", scalar @$files_removed
+        if $opt_diff_alignment;
+    foreach my $f (@$files_removed) {
+        next if $already_counted{$f};
+        # Don't proceed unless the file (both L and R versions)
+        # is in a known language.
+        next if $opt_include_lang
+            and not $Include_Language{$Language{$fset_a}{$f}};
+        next if $Language{$fset_a}{$f} eq "(unknown)";
+        next if $Exclude_Language{$fset_a}{$f};
+        ++$p_dbl{ $Language{$fset_a}{$f} }{'nFiles'}{'removed'};
+        push @p_alignment, sprintf "  - %s ; %s\n", $f, $Language{$fset_a}{$f}
+            if $opt_diff_alignment;
+        #printf "%10s -> %s\n", $f, $Language{$fh[$F  ]}{$f};
+        # Additionally, add contents of file $f to
+        #        Delta_by_File{$f}{comment/blank/code}{'removed'}
+        #        Delta_by_Language{$lang}{comment/blank/code}{'removed'}
+        # via the $p_dbl and $p_dbf variables.
+        my ($all_line_count,
+            $blank_count   ,
+            $comment_count ,
+           ) = call_counter($f, $Language{$fset_a}{$f}, \@p_errors);
+        $p_dbl{ $Language{$fset_a}{$f}}{'comment'}{'removed'} +=
+             $comment_count;
+        $p_dbl{ $Language{$fset_a}{$f}}{'blank'}{'removed'}   +=
+             $blank_count;
+        $p_dbl{ $Language{$fset_a}{$f}}{'code'}{'removed'}    +=
+             $all_line_count - $blank_count - $comment_count;
+        $p_dbf{ $f }{'comment'}{'removed'} = $comment_count;
+        $p_dbf{ $f }{'blank'}{'removed'}   = $blank_count;
+        $p_dbf{ $f }{'code'}{'removed'}    =
+            $all_line_count - $blank_count - $comment_count;
+    }
     
-        my %already_counted = (); # already_counted{ filename } = 1
+    push @p_alignment, "\n";
 
-        if (!@$file_pairs) {
-            # Special case where all files were either added or deleted.
-            # In this case, one of these arrays will be empty:
-            #   @files_added, @files_removed
-            # so loop over both to cover both cases.
-            my $status = @$files_added ? 'added' : 'removed';
-            my $fset = @$files_added ? $fset_b : $fset_a;
-            foreach my $file (@$files_added, @$files_removed) {
-                next unless defined $Language{$fset}{$file};
-                my $Lang = $Language{$fset}{$file};
-                next if $Lang eq '(unknown)';
-                my ($all_line_count,
-                    $blank_count   ,
-                    $comment_count ,
-                   ) = call_counter($file, $Lang, \@p_errors);
-                $already_counted{$file} = 1;
-                my $code_count = $all_line_count-$blank_count-$comment_count;
-                if ($opt_by_file) {
-                    $p_dbf{$file}{'code'   }{$status} += $code_count   ;
-                    $p_dbf{$file}{'blank'  }{$status} += $blank_count  ;
-                    $p_dbf{$file}{'comment'}{$status} += $comment_count;
-                    $p_dbf{$file}{'lang'   }{$status}  = $Lang         ;
-                    $p_dbf{$file}{'nFiles' }{$status} += 1             ;
-                }
-                $p_dbl{$Lang}{'code'   }{$status} += $code_count   ;
-                $p_dbl{$Lang}{'blank'  }{$status} += $blank_count  ;
-                $p_dbl{$Lang}{'comment'}{$status} += $comment_count;
-                $p_dbl{$Lang}{'nFiles' }{$status} += 1             ;
-            }
-        }
-
-        #use Data::Dumper::Simple;
-        #use Data::Dumper;
-        #print Dumper(\@files_added, \@files_removed, \@file_pairs);
-        #print "after align_by_pairs:\n";
-        #print "added:\n";
-        push @p_alignment, sprintf "Files added: %d\n", scalar @$files_added
-            if $opt_diff_alignment;
-
-        foreach my $f (@$files_added) {
-            next if $already_counted{$f};
-            #printf "%10s -> %s\n", $f, $Language{$fh[$F+1]}{$f};
-            # Don't proceed unless the file (both L and R versions)
-            # is in a known language.
-            next if $opt_include_lang
-                and not $Include_Language{$Language{$fset_b}{$f}};
-            next if $Language{$fset_b}{$f} eq "(unknown)";
-            next if $Exclude_Language{$fset_b}{$f};
-            push @p_alignment, sprintf "  + %s ; %s\n", $f, $Language{$fset_b}{$f}
-            		if $opt_diff_alignment;
-            ++$p_dbl{ $Language{$fset_b}{$f} }{'nFiles'}{'added'};
-            # Additionally, add contents of file $f to
-            # Delta_by_File{$f}{comment/blank/code}{'added'}
-            # Delta_by_Language{$lang}{comment/blank/code}{'added'}
-            # via the $p_dbl and $p_dbf variables.
-            my ($all_line_count,
-                $blank_count   ,
-                $comment_count ,
-               ) = call_counter($f, $Language{$fset_b}{$f}, \@p_errors);
-            $p_dbl{ $Language{$fset_b}{$f} }{'comment'}{'added'} +=
-               $comment_count;
-            $p_dbl{ $Language{$fset_b}{$f} }{'blank'}{'added'}   +=
-               $blank_count;
-            $p_dbl{ $Language{$fset_b}{$f} }{'code'}{'added'}    +=
-               $all_line_count - $blank_count - $comment_count;
-            $p_dbf{ $f }{'comment'}{'added'} = $comment_count;
-            $p_dbf{ $f }{'blank'}{'added'}   = $blank_count;
-            $p_dbf{ $f }{'code'}{'added'}    =
-               $all_line_count - $blank_count - $comment_count;
-        }
-
-        push @p_alignment, "\n";
-
-        #print "removed:\n";
-        push @p_alignment, sprintf "Files removed: %d\n", scalar @$files_removed
-            if $opt_diff_alignment;
-        foreach my $f (@$files_removed) {
-            next if $already_counted{$f};
-            # Don't proceed unless the file (both L and R versions)
-            # is in a known language.
-            next if $opt_include_lang
-                and not $Include_Language{$Language{$fset_a}{$f}};
-            next if $Language{$fset_a}{$f} eq "(unknown)";
-            next if $Exclude_Language{$fset_a}{$f};
-            ++$p_dbl{ $Language{$fset_a}{$f} }{'nFiles'}{'removed'};
-            push @p_alignment, sprintf "  - %s ; %s\n", $f, $Language{$fset_a}{$f}
-                if $opt_diff_alignment;
-            #printf "%10s -> %s\n", $f, $Language{$fh[$F  ]}{$f};
-            # Additionally, add contents of file $f to
-            #        Delta_by_File{$f}{comment/blank/code}{'removed'}
-            #        Delta_by_Language{$lang}{comment/blank/code}{'removed'}
-            # via the $p_dbl and $p_dbf variables.
-            my ($all_line_count,
-                $blank_count   ,
-                $comment_count ,
-               ) = call_counter($f, $Language{$fset_a}{$f}, \@p_errors);
-            $p_dbl{ $Language{$fset_a}{$f}}{'comment'}{'removed'} +=
-                 $comment_count;
-            $p_dbl{ $Language{$fset_a}{$f}}{'blank'}{'removed'}   +=
-                 $blank_count;
-            $p_dbl{ $Language{$fset_a}{$f}}{'code'}{'removed'}    +=
-                 $all_line_count - $blank_count - $comment_count;
-            $p_dbf{ $f }{'comment'}{'removed'} = $comment_count;
-            $p_dbf{ $f }{'blank'}{'removed'}   = $blank_count;
-            $p_dbf{ $f }{'code'}{'removed'}    =
-                $all_line_count - $blank_count - $comment_count;
-        }
-        push @p_alignment, "\n";
-
-         my $n_file_pairs_compared = 0;
-        # Don't know ahead of time how many file pairs will be compared
-        # since duplicates are weeded out below.  The answer is
-        # scalar @file_pairs only if there are no duplicates.
+    my $n_file_pairs_compared = 0;
+    # Don't know ahead of time how many file pairs will be compared
+    # since duplicates are weeded out below.  The answer is
+    # scalar @file_pairs only if there are no duplicates.
  
-        foreach my $pair (@$file_pairs) {
-            my $file_L = $pair->[0];
-            my $file_R = $pair->[1];
-            my $Lang_L = $Language{$fset_a}{$file_L};
-            my $Lang_R = $Language{$fset_b}{$file_R};
-            #print "main step 6 file_L=$file_L    file_R=$file_R\n";
-            ++$nCounted;
-            printf "Counting:  %d\r", $nCounted
-                unless ($counter_type or !$opt_progress_rate or ($nCounted % $opt_progress_rate));
-            next if $p_ignored{$file_L};
-            # filter out non-included languages
-            if ($opt_include_lang and not $Include_Language{$Lang_L}
-                              and not $Include_Language{$Lang_R}) {
-                $p_ignored{$file_L} = "--include-lang=$Lang_L";
-                $p_ignored{$file_R} = "--include-lang=$Lang_R";
-                next;
-            }
-            # filter out excluded or unrecognized languages
-            if ($Exclude_Language{$Lang_L} or $Exclude_Language{$Lang_R}) {
-                $p_ignored{$file_L} = "--exclude-lang=$Lang_L";
-                $p_ignored{$file_R} = "--exclude-lang=$Lang_R";
-                next;
-            }
+    foreach my $pair (@$file_pairs) {
+        my $file_L = $pair->[0];
+        my $file_R = $pair->[1];
+        my $Lang_L = $Language{$fset_a}{$file_L};
+        my $Lang_R = $Language{$fset_b}{$file_R};
+        #print "main step 6 file_L=$file_L    file_R=$file_R\n";
+        ++$nCounted;
+        printf "Counting:  %d\r", $nCounted
+             unless ($counter_type or !$opt_progress_rate or ($nCounted % $opt_progress_rate));
+        next if $p_ignored{$file_L};
+        # filter out non-included languages
+        if ($opt_include_lang and not $Include_Language{$Lang_L}
+                          and not $Include_Language{$Lang_R}) {
+            $p_ignored{$file_L} = "--include-lang=$Lang_L";
+            $p_ignored{$file_R} = "--include-lang=$Lang_R";
+            next;
+        }
+        # filter out excluded or unrecognized languages
+        if ($Exclude_Language{$Lang_L} or $Exclude_Language{$Lang_R}) {
+            $p_ignored{$file_L} = "--exclude-lang=$Lang_L";
+            $p_ignored{$file_R} = "--exclude-lang=$Lang_R";
+            next;
+        }
 
-            my $not_Filters_by_Language_Lang_LR = 0;
-            #print "file_LR = [$file_L] [$file_R]\n";
-            #print "Lang_LR = [$Lang_L] [$Lang_R]\n";
-            if (!(@{$Filters_by_Language{$Lang_L} }) or
-                !(@{$Filters_by_Language{$Lang_R} })) {
-                $not_Filters_by_Language_Lang_LR = 1;
-            }
-            if ($not_Filters_by_Language_Lang_LR) {
-                if (($Lang_L eq "(unknown)") or ($Lang_R eq "(unknown)")) {
-                    $p_ignored{$fset_a}{$file_L} = "language unknown (#1)";
-                    $p_ignored{$fset_b}{$file_R} = "language unknown (#1)";
-                } else {
-                    $p_ignored{$fset_a}{$file_L} = "missing Filters_by_Language{$Lang_L}";
-                    $p_ignored{$fset_b}{$file_R} = "missing Filters_by_Language{$Lang_R}";
-                }
-                next;
-            }
-
-            #print "DIFF($file_L, $file_R)\n";
-            # step 0: compare the two files' contents
-            chomp ( my @lines_L = read_file($file_L) );
-            chomp ( my @lines_R = read_file($file_R) );
-            my $language_file_L = "";
-            if (defined $Language{$fset_a}{$file_L}) {
-                $language_file_L = $Language{$fset_a}{$file_L};
+        my $not_Filters_by_Language_Lang_LR = 0;
+        #print "file_LR = [$file_L] [$file_R]\n";
+        #print "Lang_LR = [$Lang_L] [$Lang_R]\n";
+        if (!(@{$Filters_by_Language{$Lang_L} }) or
+            !(@{$Filters_by_Language{$Lang_R} })) {
+            $not_Filters_by_Language_Lang_LR = 1;
+        }
+        if ($not_Filters_by_Language_Lang_LR) {
+            if (($Lang_L eq "(unknown)") or ($Lang_R eq "(unknown)")) {
+                $p_ignored{$fset_a}{$file_L} = "language unknown (#1)";
+                $p_ignored{$fset_b}{$file_R} = "language unknown (#1)";
             } else {
-                # files $file_L and $file_R do not contain known language
-                next;
+                $p_ignored{$fset_a}{$file_L} = "missing Filters_by_Language{$Lang_L}";
+                $p_ignored{$fset_b}{$file_R} = "missing Filters_by_Language{$Lang_R}";
             }
+            next;
+        }
 
-            my $contents_are_same = 1;
-            if (scalar @lines_L == scalar @lines_R) {
-                # same size, must compare line-by-line
-                for (my $i = 0; $i < scalar @lines_L; $i++) {
-                    if ($lines_L[$i] ne $lines_R[$i]) {
-                        $contents_are_same = 0;
-                        last;
-                    }
-                }
-                if ($contents_are_same) {
-                    ++$p_dbl{$language_file_L}{'nFiles'}{'same'};
-                } else {
-                    ++$p_dbl{$language_file_L}{'nFiles'}{'modified'};
-                }
+        #print "DIFF($file_L, $file_R)\n";
+        # step 0: compare the two files' contents
+        chomp ( my @lines_L = read_file($file_L) );
+        chomp ( my @lines_R = read_file($file_R) );
+        my $language_file_L = "";
+        if (defined $Language{$fset_a}{$file_L}) {
+            $language_file_L = $Language{$fset_a}{$file_L};
+        } else {
+            # files $file_L and $file_R do not contain known language
+            next;
+        }
+
+        my $contents_are_same = 1;
+        if (scalar @lines_L == scalar @lines_R) {
+            # same size, must compare line-by-line
+            for (my $i = 0; $i < scalar @lines_L; $i++) {
+               if ($lines_L[$i] ne $lines_R[$i]) {
+                   $contents_are_same = 0;
+                   last;
+               }
+            }
+            if ($contents_are_same) {
+                ++$p_dbl{$language_file_L}{'nFiles'}{'same'};
             } else {
-                $contents_are_same = 0;
-                # different sizes, contents have changed
                 ++$p_dbl{$language_file_L}{'nFiles'}{'modified'};
             }
+        } else {
+            $contents_are_same = 0;
+            # different sizes, contents have changed
+            ++$p_dbl{$language_file_L}{'nFiles'}{'modified'};
+        }
 
-            if ($opt_diff_alignment) {
-                my $str =  "$file_L | $file_R ; $language_file_L";
-                if ($contents_are_same) {
-                    push @p_alignment, "  == $str";
-                } else {
-                    push @p_alignment, "  != $str";
-                }
-                ++$n_file_pairs_compared;
+        if ($opt_diff_alignment) {
+            my $str =  "$file_L | $file_R ; $language_file_L";
+            if ($contents_are_same) {
+                push @p_alignment, "  == $str";
+            } else {
+                push @p_alignment, "  != $str";
             }
+            ++$n_file_pairs_compared;
+        }
 
-            # step 1: identify comments in both files
-            #print "Diff blank removal L language= $Lang_L";
-            #print " scalar(lines_L)=", scalar @lines_L, "\n";
-            my @original_minus_blanks_L
-                    = rm_blanks(  \@lines_L, $Lang_L, \%EOL_Continuation_re);
-            #print "1: scalar(original_minus_blanks_L)=", scalar @original_minus_blanks_L, "\n";
-            @lines_L    = @original_minus_blanks_L;
-            #print "2: scalar(lines_L)=", scalar @lines_L, "\n";
-            @lines_L    = add_newlines(\@lines_L); # compensate for rm_comments()
-            @lines_L    = rm_comments( \@lines_L, $Lang_L, $file_L,
+        # step 1: identify comments in both files
+        #print "Diff blank removal L language= $Lang_L";
+        #print " scalar(lines_L)=", scalar @lines_L, "\n";
+        my @original_minus_blanks_L
+                = rm_blanks(  \@lines_L, $Lang_L, \%EOL_Continuation_re);
+        #print "1: scalar(original_minus_blanks_L)=", scalar @original_minus_blanks_L, "\n";
+        @lines_L    = @original_minus_blanks_L;
+        #print "2: scalar(lines_L)=", scalar @lines_L, "\n";
+        @lines_L    = add_newlines(\@lines_L); # compensate for rm_comments()
+        @lines_L    = rm_comments( \@lines_L, $Lang_L, $file_L,
                                    \%EOL_Continuation_re);
-            #print "3: scalar(lines_L)=", scalar @lines_L, "\n";
+        #print "3: scalar(lines_L)=", scalar @lines_L, "\n";
 
-            #print "Diff blank removal R language= $Lang_R\n";
-            my @original_minus_blanks_R
-                    = rm_blanks(  \@lines_R, $Lang_R, \%EOL_Continuation_re);
-            @lines_R    = @original_minus_blanks_R;
-            @lines_R    = add_newlines(\@lines_R); # taken away by rm_comments()
-            @lines_R    = rm_comments( \@lines_R, $Lang_R, $file_R,
+        #print "Diff blank removal R language= $Lang_R\n";
+        my @original_minus_blanks_R
+                = rm_blanks(  \@lines_R, $Lang_R, \%EOL_Continuation_re);
+        @lines_R    = @original_minus_blanks_R;
+        @lines_R    = add_newlines(\@lines_R); # taken away by rm_comments()
+        @lines_R    = rm_comments( \@lines_R, $Lang_R, $file_R,
                                    \%EOL_Continuation_re);
 
-            my (@diff_LL, @diff_LR, );
-                array_diff( $file_L                  ,   # in
+        my (@diff_LL, @diff_LR, );
+               array_diff( $file_L                  ,   # in
                    \@original_minus_blanks_L ,   # in
                    \@lines_L                 ,   # in
                    "comment"                 ,   # in
                    \@diff_LL, \@diff_LR      ,   # out
                    \@p_errors);                    # in/out
 
-            my (@diff_RL, @diff_RR, );
+        my (@diff_RL, @diff_RR, );
                 array_diff( $file_R                  ,   # in
                    \@original_minus_blanks_R ,   # in
                    \@lines_R                 ,   # in
                    "comment"                 ,   # in
                    \@diff_RL, \@diff_RR      ,   # out
                    \@p_errors);                    # in/out
-            # each line of each file is now classified as
-            # code or comment
+        # each line of each file is now classified as
+        # code or comment
+        #use Data::Dumper;
+        #print Dumper("diff_LL", \@diff_LL, "diff_LR", \@diff_LR, );
+        #print Dumper("diff_RL", \@diff_RL, "diff_RR", \@diff_RR, );
+        #die;
 
-            #use Data::Dumper;
-            #print Dumper("diff_LL", \@diff_LL, "diff_LR", \@diff_LR, );
-            #print Dumper("diff_RL", \@diff_RL, "diff_RR", \@diff_RR, );
-            #die;
-
-            # step 2: separate code from comments for L and R files
-            my @code_L = ();
-            my @code_R = ();
-            my @comm_L = ();
-            my @comm_R = ();
-            foreach my $line_info (@diff_LL) {
-                if      ($line_info->{'type'} eq "code"   ) {
-                    push @code_L, $line_info->{char};
-                } elsif ($line_info->{'type'} eq "comment") {
-                    push @comm_L, $line_info->{char};
-                } else {
-                    die "Diff unexpected line type ",
-                        $line_info->{'type'}, "for $file_L line ",
-                        $line_info->{'lnum'};
-                }
+        # step 2: separate code from comments for L and R files
+        my @code_L = ();
+        my @code_R = ();
+        my @comm_L = ();
+        my @comm_R = ();
+        foreach my $line_info (@diff_LL) {
+            if      ($line_info->{'type'} eq "code"   ) {
+                push @code_L, $line_info->{char};
+            } elsif ($line_info->{'type'} eq "comment") {
+                push @comm_L, $line_info->{char};
+            } else {
+                die "Diff unexpected line type ",
+                    $line_info->{'type'}, "for $file_L line ",
+                    $line_info->{'lnum'};
             }
+        }
 
-            foreach my $line_info (@diff_RL) {
-                if      ($line_info->{type} eq "code"   ) {
-                    push @code_R, $line_info->{'char'};
-                } elsif ($line_info->{type} eq "comment") {
-                    push @comm_R, $line_info->{'char'};
-                } else {
-                    die "Diff unexpected line type ",
-                        $line_info->{'type'}, "for $file_R line ",
-                        $line_info->{'lnum'};
-                }
+        foreach my $line_info (@diff_RL) {
+            if      ($line_info->{type} eq "code"   ) {
+                push @code_R, $line_info->{'char'};
+            } elsif ($line_info->{type} eq "comment") {
+                push @comm_R, $line_info->{'char'};
+            } else {
+                die "Diff unexpected line type ",
+                    $line_info->{'type'}, "for $file_R line ",
+                    $line_info->{'lnum'};
             }
+        }
 
         if ($opt_ignore_whitespace) {
             # strip all whitespace from each line of source code

--- a/cloc
+++ b/cloc
@@ -357,10 +357,13 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              processing will not be used. On Linux and MacOS
                              systems, cloc tries to detect the number of CPU
                              cores and creates up to one process per core by
-                             default. On systems with an unknown number
-                             of cores, using multiple processes is disabled
-                             by default. It is not possible to use multiple
-                             processes on Windows systems.
+                             default if a recent version of the
+                             Parallel::ForkManager module is available. On
+                             systems with an unknown number of cores and on
+                             systems which don't have a recent version of
+                             Parallel::ForkManager, using multiple processes
+                             is disabled by default. It is not possible to
+                             use multiple processes on Windows systems.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.

--- a/cloc
+++ b/cloc
@@ -42,6 +42,7 @@ use File::Find;
 use File::Path;
 use File::Spec;
 use IO::File;
+use Cwd;
 use POSIX qw { strftime ceil};
 
 # Parallel::ForkManager isn't in the standard distribution. Use it only if installed.
@@ -4075,7 +4076,6 @@ sub make_file_list {                         # {{{1
         push @new_file_list, $File unless $ignore_this_file;
     }
     @file_list = @new_file_list;
-
     foreach my $dir (@dir_list) {
 #print "make_file_list dir=$dir  Exclude_Dir{$dir}=$Exclude_Dir{$dir}\n";
         # populates global variable @file_list
@@ -4097,6 +4097,7 @@ sub make_file_list {                         # {{{1
     write_file($opt_found, sort @file_list) if $opt_found;
 
     my $nFiles_Categorized = 0;
+
     foreach my $file (@file_list) {
         printf "classifying $file\n" if $opt_v > 2;
 
@@ -4132,7 +4133,6 @@ die  "make_file_list($file) undef lang" unless defined $language;
     }
     printf "classified %d files\r", $nFiles_Categorized
         if !$opt_quiet and $nFiles_Categorized > 1;
-
     print "<- make_file_list()\n" if $opt_v > 2;
 
     return $fh;   # handle to the file containing the list of files to process
@@ -4298,7 +4298,7 @@ sub files {                                  # {{{1
     # invoked by File::Find's find()   Populates global variable @file_list.
     # See also find_preprocessor() which prunes undesired directories.
 
-    my $Dir = cwd(); # not $File::Find::dir which just gives relative path
+    my $Dir = fastcwd(); # not $File::Find::dir which just gives relative path
     if ($opt_fullpath) {
         # look at as much of the path as is known
         if ($opt_match_f    ) {

--- a/cloc
+++ b/cloc
@@ -1934,10 +1934,17 @@ sub get_max_processes {			     # {{{1
             return $opt_processes;
         }
     }
+
     # Disable multiprocessing on Windows - not tested.
     if ($ON_WINDOWS) {
         return 0;
     }
+ 
+    # Disable multiprocessing if Parallel::ForkManager is not available
+    if ( ! $HAVE_Parallel_ForkManager ) {
+        return 0;
+    }
+
     # Set to number of cores on Linux
     if ( -x '/usr/bin/nproc' ) {
         my $numavcores = `/usr/bin/nproc`;

--- a/cloc
+++ b/cloc
@@ -42,7 +42,14 @@ use File::Find;
 use File::Path;
 use File::Spec;
 use IO::File;
-use POSIX "strftime";
+use POSIX qw { strftime ceil};
+
+# Parallel::ForkManager isn't in the standard distribution. Use it only if installed.
+my $HAVE_Parallel_ForkManager = 0;
+eval "use Parallel::ForkManager 0.7.6;";
+if ( defined $Parallel::ForkManager::VERSION ) {
+    $HAVE_Parallel_ForkManager = 1;
+}
 
 # Digest::MD5 isn't in the standard distribution. Use it only if installed.
 my $HAVE_Digest_MD5 = 0;
@@ -342,6 +349,12 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the
                              sum of data from the individual report files.
+   --processes=NUM           Sets the maximum number of processes that cloc uses. If this
+                             parameter is set to 0, multiprocessing will not be used. On Unix systems,
+                             cloc tries to detect the number of CPU cores and creates
+                             up to one thread for each core by default. On Windows systems
+                             and on systems with an unknown number of cores,
+                             using multiple processes is disabled by default.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.
@@ -552,6 +565,7 @@ my (
     $opt_report_file          ,
     $opt_sdir                 ,
     $opt_sum_reports          ,
+    $opt_processes            ,
     $opt_unicode              ,
     $opt_no3                  ,   # accept it but don't use it
     $opt_3                    ,
@@ -630,6 +644,7 @@ my $getopt_success = GetOptions(
    "strip_comments|strip-comments=s"         => \$opt_strip_comments      ,
    "original_dir|original-dir"               => \$opt_original_dir        ,
    "sum_reports|sum-reports"                 => \$opt_sum_reports         ,
+   "processes=n"                             => \$opt_processes           ,
    "unicode"                                 => \$opt_unicode             ,
    "no3"                                     => \$opt_no3                 ,  # ignored
    "3"                                       => \$opt_3                   ,
@@ -900,6 +915,8 @@ if ($opt_lang_no_ext and !defined $Filters_by_Language{$opt_lang_no_ext}) {
 check_scale_existence(\%Filters_by_Language, \%Language_by_Extension,
                       \%Scale_Factor);
 
+my $nCounted = 0;
+
 # Process command line provided extension-to-language mapping overrides.
 # Make a hash of known languages in lower case for easier matching.
 my %Recognized_Language_lc = (); # key = language name in lc, value = true name
@@ -1112,6 +1129,9 @@ if ($opt_show_os) {
     }
     exit;
 }
+
+my $max_processes = get_max_processes();
+
 # 1}}}
 # Step 3:  Create a list of files to consider. {{{1
 #  a) If inputs are binary archives, first cd to a temp
@@ -1798,73 +1818,58 @@ printf "%8d unique file%s.                              \n",
 # 1}}}
 # Step 6:  Count code, comments, blank lines.  {{{1
 #
-
 my %Results_by_Language = ();
 my %Results_by_File     = ();
-my $nCounted = 0;
-foreach my $file (sort keys %unique_source_file) {
-    ++$nCounted;
-    printf "Counting:  %d\r", $nCounted
-        unless (!$opt_progress_rate or ($nCounted % $opt_progress_rate));
-    next if $Ignored{$file};
-    if ($opt_include_lang and not $Include_Language{$Language{$file}}) {
-        $Ignored{$file} = "--include-lang=$Language{$file}";
-        next;
-    }
-    if ($Exclude_Language{$Language{$file}}) {
-        $Ignored{$file} = "--exclude-lang=$Language{$file}";
-        next;
-    }
-    my $Filters_by_Language_Language_file = ! @{$Filters_by_Language{$Language{$file}} };
-    if ($Filters_by_Language_Language_file) {
-        if ($Language{$file} eq "(unknown)") {
-            $Ignored{$file} = "language unknown (#1)";
-        } else {
-            $Ignored{$file} = "missing Filters_by_Language{$Language{$file}}";
-        }
-        next;
-    }
-
-    my ($all_line_count, $blank_count, $comment_count, $code_count);
-    if ($opt_use_sloccount and $Language{$file} =~ /^(C|C\+\+|XML|PHP|Pascal|Java)$/) {
-        chomp ($blank_count     = `grep -Pcv '\\S' $file`);
-        chomp ($all_line_count  = `cat $file | wc -l`);
-        if      ($Language{$file} =~ /^(C|C\+\+)$/) {
-            $code_count = `cat '$file' | c_count      | head -n 1`;
-        } elsif ($Language{$file} eq "XML") {
-            $code_count = `cat '$file' | xml_count    | head -n 1`;
-        } elsif ($Language{$file} eq "PHP") {
-            $code_count = `cat '$file' | php_count    | head -n 1`;
-        } elsif ($Language{$file} eq "Pascal") {
-            $code_count = `cat '$file' | pascal_count | head -n 1`;
-        } elsif ($Language{$file} eq "Java") {
-            $code_count = `cat '$file' | java_count   | head -n 1`;
-        } else {
-            die "SLOCCount match failure: file=[$file] lang=[$Language{$file}]";
-        }
-        $code_count = substr($code_count, 0, -2);
-        $comment_count = $all_line_count - $code_count - $blank_count;
-    } else {
-        ($all_line_count,
-         $blank_count   ,
-         $comment_count ,) = call_counter($file, $Language{$file}, \@Errors);
-        $code_count = $all_line_count - $blank_count - $comment_count;
-    }
-    if ($opt_by_file) {
-        $Results_by_File{$file}{'code'   } = $code_count     ;
-        $Results_by_File{$file}{'blank'  } = $blank_count    ;
-        $Results_by_File{$file}{'comment'} = $comment_count  ;
-        $Results_by_File{$file}{'lang'   } = $Language{$file};
-        $Results_by_File{$file}{'nFiles' } = 1;
-    } else {
-        $Results_by_File{$file} = 1;  # just keep track of counted files
-    }
-
-    $Results_by_Language{$Language{$file}}{'nFiles'}++;
-    $Results_by_Language{$Language{$file}}{'code'}    += $code_count   ;
-    $Results_by_Language{$Language{$file}}{'blank'}   += $blank_count  ;
-    $Results_by_Language{$Language{$file}}{'comment'} += $comment_count;
+my @results_parts  = ();
+my @sorted_files = sort keys %unique_source_file;
+if ( $max_processes == 0) {
+    # Multiprocessing is disabled    
+    push (@results_parts , count_files ( \@sorted_files , 0, \%Language));
 }
+else {
+    # Do not create more processes than the number of files to be processed
+    my $num_files = scalar @sorted_files;
+    my $num_processes = $num_files >= $max_processes ? $max_processes : $num_files;
+    # Use at least one process.
+       $num_processes = 1
+            if $num_processes == 0;
+    # Start processes for counting
+    my $pm = Parallel::ForkManager->new($num_processes);
+    # When processes finish, they will use the embedded subroutine for
+    # merging the data into global variables.
+    $pm->run_on_finish ( sub {
+        my ($pid, $exit_code, $ident, $exit_signal, $core_dump, $part) = @_;
+        my $part_ignored = $part->{'ignored'};
+        my $part_result_by_file = $part->{'results_by_file'};
+        my $part_result_by_language = $part->{'results_by_language'};
+        my $part_errors = $part->{'errors'};
+        my $nCounted+= scalar keys %$part_result_by_file;
+        # Since files are processed by multiple processes, we can't measure
+        # the number of processed files exactly. We approximate this by showing
+        # the number of files counted by finished processes.
+	printf "Counting:  %d\r", $nCounted
+                 if $opt_progress_rate;
+
+        foreach my $this_language ( keys %$part_result_by_language ) {
+            my $counts = $part_result_by_language->{$this_language};
+            foreach my $inner_key ( keys %$counts ) {
+                $Results_by_Language{$this_language}{$inner_key} += 
+                    $counts->{$inner_key};
+            }
+        }
+        %Results_by_File = ( %Results_by_File, %$part_result_by_file );
+        push ( @Errors, @$part_errors);
+    } );
+    my $num_files_per_part = ceil ( ( scalar @sorted_files ) / $num_processes );
+    while ( my @part = splice @sorted_files, 0 , $num_files_per_part ) { 
+        $pm->start() and next;
+        my $count_result = count_files ( \@part, 1, \%Language );
+        $pm->finish(0 , $count_result);
+    }
+    # Wait for processes to finish
+    $pm->wait_all_children();
+}
+
 my @ignored_reasons = map { "$_: $Ignored{$_}" } sort keys %Ignored;
 write_file($opt_ignored, @ignored_reasons   ) if $opt_ignored;
 write_file($opt_counted, sort keys %Results_by_File) if $opt_counted;
@@ -1906,7 +1911,37 @@ if ($opt_count_diff) {
     exit if $opt_count_diff > 3;
     goto Top_of_Processing_Loop;
 }
-
+sub get_max_processes {			     # {{{1
+    # If user has specified valid number of threads, use that.
+    if (defined $opt_processes) {
+        if ( $opt_processes !~ /^\d+$/ ) {
+            print "Error: processes option argument must be numeric.\n";
+            exit 1;
+        }
+        elsif ( ! $HAVE_Parallel_ForkManager ) {
+            print "Error: cannot use multiple processes, because " .
+                  "Parallel::ForkManager is not installed, or the version is too old.\n";
+            exit 1;
+        }
+        else {
+            return $opt_processes;
+        }
+    }
+    # Disable multiprocessing on Windows - not tested.
+    if ($ON_WINDOWS) {
+        return 0;
+    }
+    # Set to number of cores on Linux
+    if ( -x '/usr/bin/nproc' ) {
+        my $numavcores = `/usr/bin/nproc`;
+        chomp $numavcores;
+        if ( $numavcores =~ /^\d+$/ ) {
+            return $numavcores;
+        }
+    }
+    # Disable multiprocessing in other cases
+    return 0;
+} # 1}}}
 sub exclude_autogenerated_files {            # {{{1
     my ($ra_file_list, # in
         $rh_Err      , # in   hash of error codes
@@ -1932,6 +1967,92 @@ sub exclude_autogenerated_files {            # {{{1
     @{$ra_file_list} = @file_list_minus_autogen;
     print "<- exclude_autogenerated_files()\n" if $opt_v > 2;
 } # 1}}}
+sub count_files {
+    my ($filelist,$counter_type,$language_hash) = @_;
+    my @p_errors = ();
+    my %p_ignored = ();
+    my %p_rbl = ();
+    my %p_rbf = ();
+    my %Language = %$language_hash;
+
+    foreach my $file (@$filelist) {
+        if ( ! $counter_type ) {
+            # Multithreading disabled
+            $nCounted++;
+            
+            printf "Counting:  %d\r", $nCounted
+                 unless (!$opt_progress_rate or ($nCounted % $opt_progress_rate));
+        }
+
+        next if $Ignored{$file};
+        if ($opt_include_lang and not $Include_Language{$Language{$file}}) {
+            $p_ignored{$file} = "--include-lang=$Language{$file}";
+            next;
+        }
+        if ($Exclude_Language{$Language{$file}}) {
+            $p_ignored{$file} = "--exclude-lang=$Language{$file}";
+            next;
+        }
+
+        my $Filters_by_Language_Language_file = ! @{$Filters_by_Language{$Language{$file}} };
+        if ($Filters_by_Language_Language_file) {
+            if ($Language{$file} eq "(unknown)") {
+                $p_ignored{$file} = "language unknown (#1)";
+            } else {
+                $p_ignored{$file} = "missing Filters_by_Language{$Language{$file}}";
+            }
+            next;
+        }
+
+        my ($all_line_count, $blank_count, $comment_count, $code_count);
+        if ($opt_use_sloccount and $Language{$file} =~ /^(C|C\+\+|XML|PHP|Pascal|Java)$/) {
+            chomp ($blank_count     = `grep -Pcv '\\S' $file`);
+            chomp ($all_line_count  = `cat $file | wc -l`);
+            if      ($Language{$file} =~ /^(C|C\+\+)$/) {
+                $code_count = `cat '$file' | c_count      | head -n 1`;
+            } elsif ($Language{$file} eq "XML") {
+                $code_count = `cat '$file' | xml_count    | head -n 1`;
+            } elsif ($Language{$file} eq "PHP") {
+                $code_count = `cat '$file' | php_count    | head -n 1`;
+            } elsif ($Language{$file} eq "Pascal") {
+                $code_count = `cat '$file' | pascal_count | head -n 1`;
+            } elsif ($Language{$file} eq "Java") {
+                $code_count = `cat '$file' | java_count   | head -n 1`;
+            } else {
+                die "SLOCCount match failure: file=[$file] lang=[$Language{$file}]";
+            }
+            $code_count = substr($code_count, 0, -2);
+            $comment_count = $all_line_count - $code_count - $blank_count;
+        } else {
+            ($all_line_count,
+             $blank_count   ,
+             $comment_count ,) = call_counter($file, $Language{$file}, \@Errors);
+            $code_count = $all_line_count - $blank_count - $comment_count;
+        }
+
+        if ($opt_by_file) {
+            $p_rbf{$file}{'code'   } = $code_count     ;
+            $p_rbf{$file}{'blank'  } = $blank_count    ;
+            $p_rbf{$file}{'comment'} = $comment_count  ;
+            $p_rbf{$file}{'lang'   } = $Language{$file};
+            $p_rbf{$file}{'nFiles' } = 1;
+        } else {
+            $p_rbf{$file} = 1;  # just keep track of counted files
+        }
+
+        $p_rbl{$Language{$file}}{'nFiles'}++;
+        $p_rbl{$Language{$file}}{'code'}    += $code_count   ;
+        $p_rbl{$Language{$file}}{'blank'}   += $blank_count  ;
+        $p_rbl{$Language{$file}}{'comment'} += $comment_count;
+
+    }    
+    return {
+        "ignored" => \%p_ignored,
+        "errors"  => \@p_errors,
+        "results_by_file" => \%p_rbf,
+        "results_by_language" => \%p_rbl,
+    }
+}
 sub exclude_dir_validates {                  # {{{1
     my ($rh_Exclude_Dir) = @_;
     my $is_OK = 1;

--- a/cloc
+++ b/cloc
@@ -352,12 +352,15 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              created with the --report-file option.  Makes
                              a cumulative set of results containing the
                              sum of data from the individual report files.
-   --processes=NUM           Sets the maximum number of processes that cloc uses. If this
-                             parameter is set to 0, multiprocessing will not be used. On Unix systems,
-                             cloc tries to detect the number of CPU cores and creates
-                             up to one thread for each core by default. On Windows systems
-                             and on systems with an unknown number of cores,
-                             using multiple processes is disabled by default.
+   --processes=NUM           Sets the maximum number of processes that cloc
+                             uses. If this parameter is set to 0, multi-
+                             processing will not be used. On Linux systems,
+                             cloc tries to detect the number of CPU cores
+                             and creates up to one process per core by
+                             default. On systems with an unknown number
+                             of cores, using multiple processes is disabled
+                             by default. It is not possible to use multiple
+                             processes on Windows systems.
    --unix                    Override the operating system autodetection
                              logic and run in UNIX mode.  See also
                              --windows, --show-os.
@@ -1419,11 +1422,17 @@ else {
                 }
             }
         }
+
+        foreach my $label ( keys %$part_alignment ) {
+            my $inner = $part_alignment->{$label};
+            foreach my $key ( keys %$inner ) {
+                $alignment{$label}{$key} = 1;
+            }
+        }
        
         %Results_by_File = ( %Results_by_File, %$part_result_by_file );
         %Delta_by_File = ( %Delta_by_File, %$part_delta_by_file );
         %Ignored = (%Ignored, %$part_ignored );
-        %alignment = ( %alignment, %$part_alignment );
         push ( @Errors, @$part_errors );
     } );
 
@@ -1664,12 +1673,16 @@ sub get_max_processes {			     # {{{1
                   "Parallel::ForkManager is not installed, or the version is too old.\n";
             exit 1;
         }
+	elsif ( $opt_processes >0 and $ON_WINDOWS ) {
+            print "Error: cannot use multiple processes on Windows systems.\n";
+            exit 1;
+        }
         else {
             return $opt_processes;
         }
     }
 
-    # Disable multiprocessing on Windows - not tested.
+    # Disable multiprocessing on Windows - does not work reliably
     if ($ON_WINDOWS) {
         return 0;
     }

--- a/cloc
+++ b/cloc
@@ -1925,7 +1925,7 @@ sub get_max_processes {			     # {{{1
             print "Error: processes option argument must be numeric.\n";
             exit 1;
         }
-        elsif ( ! $HAVE_Parallel_ForkManager ) {
+        elsif ( $opt_processes >0 and ! $HAVE_Parallel_ForkManager ) {
             print "Error: cannot use multiple processes, because " .
                   "Parallel::ForkManager is not installed, or the version is too old.\n";
             exit 1;


### PR DESCRIPTION
This PR adds support for running multiple cloc processes in order to make cloc work faster on multicore systems. This feature has been tested on Linux and MacOS. The code for using multiple processes is disabled on Windows systems, since it doesn't appear to work reliably in combination with Strawberry Perl.

The PR also includes two other minor changes:
- Cloc now uses fastcwd() instead of cwd() for performance reasons.
- The format of the diff alignment files has changed slightly: the counts for added and removed files now match the number of reported added/removed files.