### PR TITLE
Add support for gencat NLS Catalogue source files

### DIFF
--- a/Unix/t/00_C.t
+++ b/Unix/t/00_C.t
@@ -204,6 +204,11 @@ my @Tests = (
                     'args' => '../tests/inputs/fsharp_script.fsx',
                 },
                 {
+                    'name' => 'Gencat NLS',
+                    'ref'  => '../tests/outputs/Gencat-NLS.msg.yaml',
+                    'args' => '../tests/inputs/Gencat-NLS.msg',
+                },
+                {
                     'name' => 'Glade',
                     'ref'  => '../tests/outputs/glade-search-popover.ui.yaml',
                     'args' => '../tests/inputs/glade-search-popover.ui',

--- a/cloc
+++ b/cloc
@@ -6189,6 +6189,7 @@ sub set_constants {                          # {{{1
             'mll'         => 'OCaml'                 ,
             'm'           => 'MATLAB/Mathematica/Objective C/MUMPS/Mercury' ,
             'mm'          => 'Objective C++'         ,
+            'msg'         => 'Gencat NLS'            ,
             'mt'          => 'Mathematica'           ,
             'wl'          => 'Mathematica'           ,
             'wlt'         => 'Mathematica'           ,
@@ -6655,6 +6656,7 @@ sub set_constants {                          # {{{1
     'ERB'                => [
                                 [ 'remove_between_general', '<%#', '%>' ],
                             ],
+    'Gencat NLS'         => [   [ 'remove_matches'       , '^\$ .*$' ], ],
     'NASTRAN DMAP'       => [
                                 [ 'remove_matches'      , '^\s*\$' ],
                                 [ 'remove_inline'       , '\$.*$'  ],
@@ -7436,6 +7438,7 @@ sub set_constants {                          # {{{1
     'D'                  =>     '\\\\$'         ,
     'Dart'               =>     '\\\\$'         ,
     'Expect'             =>     '\\\\$'         ,
+    'Gencat NLS'         =>     '\\\\$'         ,
     'Go'                 =>     '\\\\$'         ,
     'IDL'                =>     '\$\\$'         ,
     'Java'               =>     '\\\\$'         ,
@@ -8245,6 +8248,7 @@ sub set_constants {                          # {{{1
     'zim'                          =>   4.21,
     'zlisp'                        =>   1.25,
     'Expect'                       => 2.00,
+    'Gencat NLS'                   => 1.50,
     'C/C++ Header'                 => 1.00,
     'inc'                          => 1.00,
     'lex'                          => 1.00,

--- a/tests/inputs/Gencat-NLS.msg
+++ b/tests/inputs/Gencat-NLS.msg
@@ -1,0 +1,19 @@
+$ Base file borrowed from $FreeBSD$
+$ freebsd/usr.bin/grep/nls/C.msg
+$ 
+
+$set 1
+$quote "
+1 "(standard input)"
+2 "cannot read bzip2 compressed file"
+3 "unknown %s option"
+4 "usage: %s [-abcDEFGHhIiJLlmnOoPqRSsUVvwxZ] [-A num] [-B num] [-C[num]]\n"
+5 "\t[-e pattern] [-f file] [--binary-files=value] [--color=when]\n"
+6 "\t[--context[=num]] [--directories=action] [--label] [--line-buffered]\n"
+7 "\t[--null] [pattern] [file ...]\n"
+8 "Binary file %s matches\n"
+9 "%s (BSD grep) %s\n"
+10 "cloc \\ but not a line continued"
+12 "cloc a line is continued\\
+until the bitter end"
+$ empty:1 comment:4 code:14

--- a/tests/inputs/Gencat-NLS.msg.yaml
+++ b/tests/inputs/Gencat-NLS.msg.yaml
@@ -1,0 +1,21 @@
+---
+# github.com/AlDanial/cloc
+header : 
+  cloc_url           : github.com/AlDanial/cloc
+  cloc_version       : 1.75
+  elapsed_seconds    : 0.0146248340606689
+  n_files            : 1
+  n_lines            : 17
+  files_per_second   : 68.376844198823
+  lines_per_second   : 1162.40635137999
+  report_file        : C.msg
+Gencat NLS :
+  nFiles: 1
+  blank: 0
+  comment: 5
+  code: 12
+SUM: 
+  blank: 0
+  comment: 5
+  code: 12
+  nFiles: 1


### PR DESCRIPTION
The gencat utility is a part of the X/Open Portability Guide
and in freebsd the standard suffix .msg is used for the input
files. Set the scale factor to 1.50 but am unsuer if this is
correct, its same used by the 'PO File' translation files. Added
a simple test example based on a modified freebsd file.

Signed-off-by: Alan Robinson <Alan.Robinson@ts.fujitsu.com>