### PR TITLE
Don't inherit all Pascal comments for OCaml

### DIFF
--- a/cloc
+++ b/cloc
@@ -7015,7 +7015,7 @@ sub set_constants {                          # {{{1
                                 [ 'call_regexp_common'  , 'C++'    ],
                             ],
     'OCaml'              => [
-                                [ 'call_regexp_common'  , 'Pascal' ],
+                                [ 'remove_between_general', '(*', '*)' ],
                             ],
     'OpenCL'             => [
                                 [ 'call_regexp_common'  , 'C++'    ],


### PR DESCRIPTION
Curly brackets aren't comments in OCaml.

```
(* comment *)
type foobar = {                    
    a : int;                       
    b : string;                    
}                                  
(* a
   multiline 
     comment 
*)                                   
let () =                           
  let foo = {                      
      a=100;                       
      b="bar" 
  } in                             
  Printf.printf "%s %d" foo.b foo.a
```

```
<<<
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
OCaml                            1              1             10              5
-------------------------------------------------------------------------------
>>>
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
OCaml                            1              1              5             10
-------------------------------------------------------------------------------
```