### PR TITLE
fix: add support for more comments in idris

### DIFF
--- a/cloc
+++ b/cloc
@@ -7293,8 +7293,8 @@ sub set_constants {                          # {{{1
     'IDL'                => [   [ 'remove_matches'      , '^\s*;'  ], ],
     'IDL/Qt Project/Prolog/ProGuard' => [ [ 'die' ,          ], ], # never called
     'Idris'              => [
-                                [ 'remove_matches'      , '^--'    ],
-                                [ 'remove_matches'      , '^\|{3}' ],
+                                [ 'remove_haskell_comments', '>filename<' ],
+                                [ 'remove_matches'      , '^\s*\|{3}' ],
                             ],
     'Igor Pro'           => [
                                 [ 'remove_matches'      , '^\s*//' ],

--- a/tests/inputs/test.idr
+++ b/tests/inputs/test.idr
@@ -1,0 +1,20 @@
+--
+-- A module about shapes
+--
+
+||| a Shape
+data Shape =
+  ||| Triangle with base and heigth
+  Triangle Double Double |
+  ||| Circle with radius
+  Circle Double
+
+||| computes the area of a shape
+area : Shape -> Double
+area (Triangle x y) = 0.5 * x * y
+area (Circle x) = pi * x * x
+                  -- pi is known by idris
+
+{-
+commented out code
+-}

--- a/tests/outputs/test.idr.yaml
+++ b/tests/outputs/test.idr.yaml
@@ -1,0 +1,21 @@
+---
+# github.com/AlDanial/cloc
+header :
+  cloc_url           : github.com/AlDanial/cloc
+  cloc_version       : 1.77
+  elapsed_seconds    : 0.00631189346313477
+  n_files            : 1
+  n_lines            : 20
+  files_per_second   : 158.431064440583
+  lines_per_second   : 3168.62128881166
+  report_file        : test.idr.yaml
+Idris :
+  nFiles: 1
+  blank: 3
+  comment: 11
+  code: 6
+SUM:
+  blank: 3
+  comment: 11
+  code: 6
+  nFiles: 1


### PR DESCRIPTION
New comments are supported: block comments, indented documentation comments, indented line comments.

closes #316