### PR TITLE
Fix unescaped left bracket in Unix/cloc.

### DIFF
--- a/Unix/cloc
+++ b/Unix/cloc
@@ -8552,7 +8552,7 @@ sub Perl_or_Prolog {                         # {{{1
     my $prolog_points = 0;
     while (<$IN>) {
         ++$perl_points if  /;\s*$/;
-        ++$perl_points if  /({|})/;
+        ++$perl_points if  /(\{|})/;
         ++$perl_points if  /^\s*sub\s+/;
         ++$perl_points if  /\s*<<'/;  # start HERE block
         ++$perl_points if  /\$(\w+\->|[_!])/;


### PR DESCRIPTION
Perl (-v 5.28) emitted this warning:

    Unescaped left brace in regex is deprecated here (and will be fatal in Perl
    5.32), passed through in regex; marked by <-- HERE in m/({ <-- HERE |})/ at
    /usr/bin/cloc line 8555.