### PR TITLE
Avoid undefined value as ARRAY ref

### DIFF
--- a/cloc
+++ b/cloc
@@ -1938,13 +1938,14 @@ sub count_files {                            # {{{1
             next;
         }
 
+        if ($Language{$file} eq "(unknown)") {
+            $p_ignored{$file} = "language unknown (#1)";
+            next;
+        }
+
         my $Filters_by_Language_Language_file = ! @{$Filters_by_Language{$Language{$file}} };
         if ($Filters_by_Language_Language_file) {
-            if ($Language{$file} eq "(unknown)") {
-                $p_ignored{$file} = "language unknown (#1)";
-            } else {
-                $p_ignored{$file} = "missing Filters_by_Language{$Language{$file}}";
-            }
+            $p_ignored{$file} = "missing Filters_by_Language{$Language{$file}}";
             next;
         }
 


### PR DESCRIPTION
Avoid "Can't use an undefined value as an ARRAY reference at cloc line 1942" when language is unknown.

This is a bit of a long shot. The source seemed to be that in the project I was checking we had some conflicting file types & extensions. I'm far from well familiar with this project, but it seems to me that if "(unknown)" language has no filters, we should check for that and avoid the exception we'd hit here otherwise:
`my $Filters_by_Language_Language_file = ! @{$Filters_by_Language{$Language{$file}} };`