### PR TITLE
add escript as script language for erlang

### DIFF
--- a/cloc
+++ b/cloc
@@ -6875,6 +6875,7 @@ sub set_constants {                          # {{{1
             'csh'      => 'C Shell'               ,
             'dmd'      => 'D'                     ,
             'dtrace'   => 'dtrace'                ,
+            'escript'  => 'Erlang'                ,
             'idl'      => 'IDL'                   ,
             'kermit'   => 'Kermit'                ,
             'ksh'      => 'Korn Shell'            ,


### PR DESCRIPTION
In erlang you can have #! lines with escript which is scripted erlang, so adding to the constants.