### PR TITLE
Change to STDOUT in terminal check

### DIFF
--- a/cloc
+++ b/cloc
@@ -143,9 +143,9 @@ if ( $ENV{'HOME'} ) {
 }
 
 my $NN     = chr(27) . "[0m";  # normal
-   $NN     = "" if $ON_WINDOWS or !(-t STDERR); # -t STDERR:  is it a terminal?
+   $NN     = "" if $ON_WINDOWS or !(-t STDOUT); # -t STDOUT:  is it a terminal?
 my $BB     = chr(27) . "[1m";  # bold
-   $BB     = "" if $ON_WINDOWS or !(-t STDERR);
+   $BB     = "" if $ON_WINDOWS or !(-t STDOUT);
 my $script = basename $0;
 my $brief_usage  = "
                        cloc -- Count Lines of Code


### PR DESCRIPTION
This removes escape sequences when stdout is redirected, e.g. `cloc --help | less`.
It appears escape sequences are only used when printing to stdout anyway.