### PR TITLE
Mask comment markers in Kotlin raw strings

### DIFF
--- a/cloc
+++ b/cloc
@@ -8329,6 +8329,8 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , '#.*$'   ],
                             ],
     'Kotlin'             => [
+                                [ 'rm_comments_in_strings', '"""', '/*', '*/', 1],
+                                [ 'rm_comments_in_strings', '"""', '//', '', 1],
                                 [ 'rm_comments_in_strings', '"', '/*', '*/' ],
                                 [ 'rm_comments_in_strings', '"', '//', '' ],
                                 [ 'call_regexp_common'  , 'C++'    ],


### PR DESCRIPTION
This ensures that cloc with the --strip-str-comments option handles Kotlin raw strings correctly. 

Example: 

```
fun main(args: Array<String>) {
    println("""
/* Hello world */
""")
}
```

The "/* Hello world */" line in the fragment should be counted as code, rather than a comment.

It's probably best to merge this PR after https://github.com/AlDanial/cloc/pull/436, since #436 fixes an edge case that is relevant to Kotlin raw strings.