### PR TITLE
#458 fix - Git+diff slower & wrong since 1.84

### DIFF
--- a/Unix/t/02_git.t
+++ b/Unix/t/02_git.t
@@ -33,12 +33,26 @@ my @Tests = (
                     'cd'   => 'cloc_submodule_test',
                 },
 
-#               {
-#                   'name' => 'diff f15bf042b f647093e8b',
-#                   'args' => '--git --diff f15bf042b f647093e8b',
-#                   'ref'  => '../tests/outputs/git_tests/diff_f15bf042b_f647093e8b.yaml',
-#                   'cd'   => 'cloc_submodule_test',
-#               },
+                {
+                    'name' => 'diff f15bf042b f647093e8b',
+                    'args' => '--git --diff f15bf042b f647093e8b',
+                    'ref'  => '../tests/outputs/git_tests/diff_f15bf042b_f647093e8b.yaml',
+                    'cd'   => 'cloc_submodule_test',
+                },
+
+                {
+                    'name' => 'diff commit with only deleted file',
+                    'args' => '--strip-str-comments --git --diff 04179b6 ae0d26e',
+                    'ref'  => '../tests/outputs/git_tests/04179b6_ae0d26e.yaml',
+                    'cd'   => 'cloc_submodule_test',
+                },
+
+                {
+                    'name' => 'diff commit with only added file',
+                    'args' => '--strip-str-comments --git --diff f15bf04 d9b6726',
+                    'ref'  => '../tests/outputs/git_tests/f15bf04_d9b6726.yaml',
+                    'cd'   => 'cloc_submodule_test',
+                },
 
                 {
                     'name' => 'count and diff part I',

--- a/cloc
+++ b/cloc
@@ -4609,20 +4609,22 @@ sub replace_git_hash_with_tarfile {          # {{{1
             # first make a union of all files that have changed in both commits
             my %files_union = ();
 
-            # Strategy 1:  Union files are what git consinders have changed
-            #              between the two commits.
-##          my $git_list_cmd = "git diff-tree -r --no-commit-id --name-only $Left $Right";
-##          print "$git_list_cmd\n" if $opt_v;
-##          foreach my $file (`$git_list_cmd`) {
-##              chomp($file);
-##              $files_union{$file} = 1;
-##          }
-
-            # Strategy 2:  Union files all files that have changed in both
-            #              commits.
-            foreach my $file (keys %{$repo_listing{$Left }},
-                              keys %{$repo_listing{$Right}}) {
-                $files_union{$file} = 1;
+            if($opt_count_diff != 3) {
+                # Strategy 1:  Union files are what git consinders have changed
+                #              between the two commits.
+                my $git_list_cmd = "git diff-tree -r --no-commit-id --name-only $Left $Right";
+                # print "$git_list_cmd\n" if $opt_v;
+                foreach my $file (`$git_list_cmd`) {
+                    chomp($file);
+                    $files_union{$file} = 1;
+                }
+            } else {
+                # Strategy 2:  Union files all files that have changed in both
+                #              commits.
+                foreach my $file (keys %{$repo_listing{$Left }},
+                                  keys %{$repo_listing{$Right}}) {
+                   $files_union{$file} = 1;
+                }
             }
 
 #use Data::Dumper;
@@ -4641,7 +4643,13 @@ sub replace_git_hash_with_tarfile {          # {{{1
 
 #           my @Lfiles= map {$_ =~ s/([\s\(\)\[\]{}';\^\$\?])/\\$1/g; $_}   @left_files;
 #           my @Lfiles= @left_files;
-            $replacement_arg_list{$git_hash{$Left}}  = git_archive($Left , \@left_files);
+            if(scalar(@left_files) > 0) {
+                $replacement_arg_list{$git_hash{$Left}}  = git_archive($Left , \@left_files);
+            } else {
+                # In the right side commit ONLY file(s) was added, so no file(s) will exist in the left side commit.
+                # Create empty TAR to detect added lines of code.
+                $replacement_arg_list{$git_hash{$Left}} = empty_tar();
+            }
 #           $replacement_arg_list{$git_hash{$Left}}  = git_archive($Left , \@Lfiles);
 #           my @Rfiles= map {$_ =~ s/([\s\(\)\[\]{}';\^\$\?])/\\$1/g; $_}   @right_files ;
 #           my @Rfiles= @right_files ;
@@ -4649,7 +4657,14 @@ sub replace_git_hash_with_tarfile {          # {{{1
 #print Dumper('left' , \@left_files);
 #print Dumper('right', \@right_files);
 #die;
-            $replacement_arg_list{$git_hash{$Right}} = git_archive($Right, \@right_files);
+
+            if(scalar(@right_files) > 0) {
+                $replacement_arg_list{$git_hash{$Right}} = git_archive($Right, \@right_files);
+            } else {
+                 # In the left side commit ONLY file(s) was deleted, so file(s) will not exist in right side commit.
+                 # Create empty TAR to detect removed lines of code.
+                 $replacement_arg_list{$git_hash{$Right}} = empty_tar();
+            }
 #           $replacement_arg_list{$git_hash{$Right}} = git_archive($Right, \@Rfiles);
 #write_file("/tmp/Lfiles.txt", {}, sort @Lfiles);
 #write_file("/tmp/Rfiles.txt", {}, sort @Rfiles);
@@ -4694,6 +4709,26 @@ sub replace_git_hash_with_tarfile {          # {{{1
 #print "ra_arg_list 2: @{$ra_arg_list}\n";
     print "<- replace_git_hash_with_tarfile()\n" if $opt_v > 2;
 } # 1}}}
+
+sub empty_tar {
+    my ($Tarfh, $Tarfile);
+    if ($opt_sdir) {
+      File::Path::mkpath($opt_sdir) unless is_dir($opt_sdir);
+      ($Tarfh, $Tarfile) = tempfile(UNLINK => 1, DIR => $opt_sdir, SUFFIX => $ON_WINDOWS ? '.zip' : '.tar');  # delete on exit
+    } else {
+      ($Tarfh, $Tarfile) = tempfile(UNLINK => 1, SUFFIX => $ON_WINDOWS ? '.zip' : '.tar');  # delete on exit
+    }
+    my $cmd = $ON_WINDOWS ? "type nul > $Tarfile" : "touch $Tarfile";
+    print  $cmd, "\n" if $opt_v;
+    system $cmd;
+    if (!-r $Tarfile) {
+        # not readable
+        die "Failed to create empty tarfile.";
+    }
+
+    return $Tarfile;
+}
+
 sub git_archive {                            # {{{1
     # Invoke 'git archive' as a system command to create a tar file
     # using the given argument(s).

--- a/cloc
+++ b/cloc
@@ -4718,7 +4718,7 @@ sub empty_tar {
     } else {
       ($Tarfh, $Tarfile) = tempfile(UNLINK => 1, SUFFIX => $ON_WINDOWS ? '.zip' : '.tar');  # delete on exit
     }
-    my $cmd = $ON_WINDOWS ? "type nul > $Tarfile" : "touch $Tarfile";
+    my $cmd = $ON_WINDOWS ? "type nul > $Tarfile" : "tar -cf $Tarfile -T /dev/null";
     print  $cmd, "\n" if $opt_v;
     system $cmd;
     if (!-r $Tarfile) {

--- a/tests/outputs/git_tests/04179b6_ae0d26e.yaml
+++ b/tests/outputs/git_tests/04179b6_ae0d26e.yaml
@@ -1,0 +1,56 @@
+---
+# github.com/AlDanial/cloc
+header : 
+  cloc_url           : github.com/AlDanial/cloc
+  cloc_version       : 1.85
+  elapsed_seconds    : 0.123239994049072
+  n_files            : 1
+  n_lines            : 555
+  files_per_second   : 8.11424901239297
+  lines_per_second   : 4503.4082018781
+  report_file        : 04179b6_ae0d26e.yaml
+added :
+  'C++' :
+    comment : 0
+    code : 0
+    blank : 0
+    nFiles : 0
+same :
+  'C++' :
+    comment : 0
+    code : 0
+    blank : 0
+    nFiles : 0
+modified :
+  'C++' :
+    comment : 0
+    code : 0
+    blank : 0
+    nFiles : 0
+removed :
+  'C++' :
+    comment : 114
+    code : 365
+    blank : 76
+    nFiles : 1
+SUM :
+  added :
+    nFiles : 0
+    blank : 0
+    comment : 0
+    code : 0
+  same :
+    nFiles : 0
+    blank : 0
+    comment : 0
+    code : 0
+  modified :
+    nFiles : 0
+    blank : 0
+    comment : 0
+    code : 0
+  removed :
+    nFiles : 1
+    blank : 76
+    comment : 114
+    code : 365

--- a/tests/outputs/git_tests/f15bf04_d9b6726.yaml
+++ b/tests/outputs/git_tests/f15bf04_d9b6726.yaml
@@ -1,0 +1,56 @@
+---
+# github.com/AlDanial/cloc
+header : 
+  cloc_url           : github.com/AlDanial/cloc
+  cloc_version       : 1.85
+  elapsed_seconds    : 0.122870922088623
+  n_files            : 1
+  n_lines            : 3
+  files_per_second   : 8.13862208406583
+  lines_per_second   : 24.4158662521975
+  report_file        : f15bf04_d9b6726.yaml
+added :
+  'MATLAB' :
+    code : 2
+    blank : 0
+    nFiles : 1
+    comment : 1
+same :
+  'MATLAB' :
+    code : 0
+    blank : 0
+    nFiles : 0
+    comment : 0
+modified :
+  'MATLAB' :
+    code : 0
+    blank : 0
+    nFiles : 0
+    comment : 0
+removed :
+  'MATLAB' :
+    code : 0
+    blank : 0
+    nFiles : 0
+    comment : 0
+SUM :
+  added :
+    code : 2
+    blank : 0
+    nFiles : 1
+    comment : 1
+  same :
+    code : 0
+    blank : 0
+    nFiles : 0
+    comment : 0
+  modified :
+    code : 0
+    blank : 0
+    nFiles : 0
+    comment : 0
+  removed :
+    code : 0
+    blank : 0
+    nFiles : 0
+    comment : 0


### PR DESCRIPTION
1. Git & Diff now only compares all touch files or commits which only added or deleted files.
2. Git-Diff-Count still stays with the strategy to compare all files.
3. Added also more test.