### PR TITLE
Add support for ASP.NET Core Blazor WASM (*.razor)

### DIFF
--- a/Unix/cloc
+++ b/Unix/cloc
@@ -7166,6 +7166,7 @@ sub set_constants {                          # {{{1
             'master'      => 'ASP.NET'               ,
             'sitemap'     => 'ASP.NET'               ,
             'cshtml'      => 'Razor'                 ,
+            'razor'       => 'Razor'                 , # Client-side Blazor
             'nawk'        => 'awk'                   ,
             'mawk'        => 'awk'                   ,
             'gawk'        => 'awk'                   ,


### PR DESCRIPTION
`*.razor` files are used for ASP.NET Core Blazor WASM (Client-side) components. They have a similar syntax to `*.cshtml` files, including the use of the comment tag set `@* *@`.

I have tested this successfully on a project I am currently developing which uses Blazor WASM components with this file type.

More information on Blazor WASM can be found at the Microsoft Documentation page for it [here](https://docs.microsoft.com/en-us/aspnet/core/blazor/hosting-models?view=aspnetcore-3.1#blazor-webassembly).