### PR TITLE
Add mojo

### DIFF
--- a/Unix/t/00_C.t
+++ b/Unix/t/00_C.t
@@ -498,7 +498,7 @@ my @Tests = (
                 },
                 {
                     'name' => 'Mojo',
-                    'ref'  => '../tests/outputs/Mojo.yaml',
+                    'ref'  => '../tests/outputs/Mojo.mojom.yaml',
                     'args' => '../tests/inputs/Mojo.mojom',
                 },
                 {

--- a/Unix/t/00_C.t
+++ b/Unix/t/00_C.t
@@ -497,6 +497,11 @@ my @Tests = (
                     'args' => '../tests/inputs/meson.build',
                 },
                 {
+                    'name' => 'Mojo',
+                    'ref'  => '../tests/outputs/Mojo.yaml',
+                    'args' => '../tests/inputs/Mojo.mojom',
+                },
+                {
                     'name' => 'Mumps',
                     'ref'  => '../tests/outputs/Mumps.mps.yaml',
                     'args' => '../tests/inputs/Mumps.mps',

--- a/cloc
+++ b/cloc
@@ -7581,6 +7581,7 @@ sub set_constants {                          # {{{1
             'mc'          => 'Windows Message File'  ,
             'met'         => 'Teamcenter met'        ,
             'mg'          => 'Modula3'               ,
+            'mojom'       => 'Mojo'                  ,
             'meson.build' => 'Meson'                 ,
             'mk'          => 'make'                  ,
 #           'mli'         => 'ML'                    , # ML not implemented
@@ -8742,6 +8743,7 @@ sub set_constants {                          # {{{1
     'Modula3'            => [   [ 'call_regexp_common'  , 'Pascal' ], ],
         # Modula 3 comments are (* ... *) so applying the Pascal filter
         # which also treats { ... } as a comment is not really correct.
+    'Mojo'               => [   [ 'call_regexp_common' , 'C++' ], ],
     'Nemerle'            => [
                                 [ 'rm_comments_in_strings', '"', '/*', '*/' ],
                                 [ 'rm_comments_in_strings', '"', '//', '' ],
@@ -10230,6 +10232,7 @@ sub set_constants {                          # {{{1
     'Octave'                       => 4.00,
     'ML'                           => 3.00,
     'Modula3'                      => 2.00,
+    'Mojo'                         => 2.00,
     'PHP'                          => 3.50,
     'Jupyter Notebook'             => 4.20,
     'Python'                       => 4.20,

--- a/tests/inputs/Mojo.mojom
+++ b/tests/inputs/Mojo.mojom
@@ -1,0 +1,27 @@
+// Mojo files usually start with a multiline comment and/or copyright
+// statement.  They are otherwise quite close to C++ files.
+
+module example_service.mojom;
+
+import "mojo/public/mojom/base/time.mojom";
+import "some/other/project/base.mojom";
+
+enum BasicEnum {
+  kField1,
+  kField2,
+};
+
+struct BasicStruct {
+  // Comment about a field.
+  mojo_base.mojom.TimeDelta duration;
+};
+
+[annotation]
+interface ExampleInterface {
+  // Returns a thing from a place using its arguments.
+  DecodeInput(array<uint8> input_data, BasicEnum value, bool flag,
+              int64 size_of_the_thing)
+      => (BasicStruct? result_maybe);
+
+  Frobnicate(map<StringPair, map<int32, array<map<string, string>?>?>?> ridiculous) => (array<unit64, 2> guid);
+};

--- a/tests/outputs/Mojo.mojom.yaml
+++ b/tests/outputs/Mojo.mojom.yaml
@@ -1,0 +1,21 @@
+---
+# github.com/AlDanial/cloc
+header : 
+  cloc_url           : github.com/AlDanial/cloc
+  cloc_version       : 1.87
+  elapsed_seconds    : 0.0278570652008057
+  n_files            : 1
+  n_lines            : 27
+  files_per_second   : 35.8975359676826
+  lines_per_second   : 969.23347112743
+  report_file        : .\tests\outputs\example_mojo.mojom.yaml
+'Mojo' :
+  nFiles: 1
+  blank: 6
+  comment: 4
+  code: 17
+SUM: 
+  blank: 6
+  comment: 4
+  code: 17
+  nFiles: 1


### PR DESCRIPTION
Mojo is used as an IDL by Chromium and other projects.

Mojo is documented by https://chromium.googlesource.com/chromium/src.git/+/master/mojo/README.md

For the purpose of counting lines of code, C++ is adequate. There are no line continuations.

Output from chromium:-

```
---------------------------------------------------------------------------------------
Language                             files          blank        comment           code
---------------------------------------------------------------------------------------
C++                                  93867        6705502        5235455       37961225
...
Mojo                                  1044          11480          28358          37732
```