### PR TITLE
Add OpenBSD installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ a Perl interpreter):
     sudo pacman -S cloc                    # Arch
     sudo emerge -av dev-util/cloc          # Gentoo https://packages.gentoo.org/packages/dev-util/cloc
     sudo apk add cloc                      # Alpine Linux
+    doas pkg_add cloc                      # OpenBSD
     sudo pkg install cloc                  # FreeBSD
     sudo port install cloc                 # Mac OS X with MacPorts
     brew install cloc                      # Mac OS X with Homebrew


### PR DESCRIPTION
This port is maintained by Joerg Jung (not me) and is of version 1.84. It worked great out of the box on my installation.

Happy hacking!