### PR TITLE
Fixing macOS spelling

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -13,7 +13,7 @@ A concise description of the problem you found with cloc.
 **cloc; OS; OS version**
  - cloc version:
  - If running the cloc source, Perl version:
- - OS (eg Linux, Windows, Mac OS, etc):
+ - OS (eg Linux, Windows, macOS, etc):
  - OS version:
 
 **To Reproduce**

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ standard distribution of Perl v5.6 and higher (code from some external
 modules is [embedded within
 cloc](https://github.com/AlDanial/cloc#regexp_common)) and so is
 quite portable. cloc is known to run on many flavors of Linux, FreeBSD,
-NetBSD, OpenBSD, Mac OS X, AIX, HP-UX, Solaris, IRIX, z/OS, and Windows.
+NetBSD, OpenBSD, macOS, AIX, HP-UX, Solaris, IRIX, z/OS, and Windows.
 (To run the Perl source version of cloc on Windows one needs
 [ActiveState Perl](http://www.activestate.com/activeperl) 5.6.1 or
 higher, [Strawberry Perl](http://strawberryperl.com/),
@@ -251,8 +251,8 @@ a Perl interpreter):
     sudo apk add cloc                # Alpine Linux
     doas pkg_add cloc                # OpenBSD
     sudo pkg install cloc            # FreeBSD
-    sudo port install cloc           # Mac OS X with MacPorts
-    brew install cloc                # Mac OS X with Homebrew
+    sudo port install cloc           # macOS with MacPorts
+    brew install cloc                # macOS with Homebrew
     choco install cloc               # Windows with Chocolatey
     scoop install cloc               # Windows with Scoop
 
@@ -293,7 +293,7 @@ cloc has many features that make it easy to use, thorough, extensible, and porta
 6.  Has numerous troubleshooting options.
 7.  Handles file and directory names with spaces and other unusual characters.
 8.  Has no dependencies outside the standard Perl distribution.
-9.  Runs on Linux, FreeBSD, NetBSD, OpenBSD, Mac OS X, AIX, HP-UX, Solaris, IRIX, and z/OS systems that have Perl 5.6 or higher. The source version runs on Windows with either ActiveState Perl, Strawberry Perl, Cygwin, or MobaXTerm+Perl plugin. Alternatively on Windows one can run the Windows binary which has no dependencies.
+9.  Runs on Linux, FreeBSD, NetBSD, OpenBSD, macOS, AIX, HP-UX, Solaris, IRIX, and z/OS systems that have Perl 5.6 or higher. The source version runs on Windows with either ActiveState Perl, Strawberry Perl, Cygwin, or MobaXTerm+Perl plugin. Alternatively on Windows one can run the Windows binary which has no dependencies.
 [](1}}})
 
 <a name="Other_Counters"></a> []({{{1)
@@ -2708,7 +2708,7 @@ time you invoke cloc, you can save some typing by adding those
 switches to the ``options.txt`` runtime configuration file.
 cloc will look for this file in the following locations:
 <pre>
-# Linux, NetBSD, FreeBSD, Mac OSX:
+# Linux, NetBSD, FreeBSD, macOS:
 /home/USERNAME/.config/cloc/options.txt
 
 # Windows

--- a/Unix/cloc
+++ b/Unix/cloc
@@ -2230,7 +2230,7 @@ sub get_max_processes {                      # {{{1
         }
     }
 
-    # Set to number of cores on MacOS
+    # Set to number of cores on macOS
     if ( $^O =~ /darwin/i and -x '/usr/sbin/sysctl') {
        my $numavcores_macos = `/usr/sbin/sysctl -n hw.physicalcpu`;
        chomp $numavcores_macos;

--- a/Unix/pod2man.mk
+++ b/Unix/pod2man.mk
@@ -28,7 +28,7 @@
 #	    man:
 #		    make -f pod2man.mk PACKAGE=$(PACKAGE) makeman
 #
-#	    build: man
+#	    build: man  
 
 ifneq (,)
     This makefile requires GNU Make.
@@ -43,7 +43,7 @@ PODCENTER	?= User Commands
 PODDATE		?= $$(date --utc --date="@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" "+%Y-%m-%d")
 detected_OS = $(shell uname)
 ifeq ($(detected_OS),Darwin)
-	# Mac OS X;  "PODDATE ?=" doesn't work
+	# macOS;  "PODDATE ?=" doesn't work
 	PODDATE = $(shell date -u "+%Y-%m-%d")
 endif
 # add other OS exceptions as they arise

--- a/Unix/why_this_directory_exists.txt
+++ b/Unix/why_this_directory_exists.txt
@@ -1,6 +1,6 @@
 The contents of the cloc/Unix/ directory are intended for
 cloc package maintainers on distributions such as Ubuntu,
-Debian, Fedora, Gentoo, Mint, SUSE, FreeBSD, Mac OSX.
+Debian, Fedora, Gentoo, Mint, SUSE, FreeBSD, macOS.
 
 Each time cloc is released, the cloc executable in this
 directory is updated to the latest version, minus the

--- a/cloc
+++ b/cloc
@@ -2220,7 +2220,7 @@ sub get_max_processes {                      # {{{1
         }
     }
 
-    # Set to number of cores on MacOS
+    # Set to number of cores on macOS
     if ( $^O =~ /darwin/i and -x '/usr/sbin/sysctl') {
        my $numavcores_macos = `/usr/sbin/sysctl -n hw.physicalcpu`;
        chomp $numavcores_macos;

--- a/tests/inputs/tictactoe3d.ring
+++ b/tests/inputs/tictactoe3d.ring
@@ -17,7 +17,7 @@
 	load "opengl21lib.ring"		# RingOpenGL  Library
 
 #==============================================================
-# To Support MacOS X
+# To Support macOS
 	al_run_main()	
 	func al_game_start 	# Called by al_run_main()
 		main()		# Now we call our main function


### PR DESCRIPTION
Fixed the spelling of macOS (apple renamed MacOS X to mac in 2016)