### PR TITLE
Exclude DOS batch `::` comments.

### DIFF
--- a/cloc
+++ b/cloc
@@ -8827,8 +8827,8 @@ sub set_constants {                          # {{{1
                                 [ 'remove_inline'       , '#.*$'   ],
                             ],
     'DOS Batch'          => [   
-                                [ 'remove_matches'      , '^\s*rem', ],
-                                [ 'remove_matches'      , '^\s*::', ],
+                                [ 'remove_matches'      , '^\s*rem' ],
+                                [ 'remove_matches'      , '^\s*::'  ],
                             ],
     'DTD'                => [   [ 'remove_html_comments',          ],
                                 [ 'call_regexp_common'  , 'HTML'   ], ],


### PR DESCRIPTION
In batch files, it is possible to use `::` for adding comments, apart from the documented `rem` command. Eg:
```bat
rem This is a comment!
:: This is a comment too!
```
This PR basically adds another regex match in DOS Batch.