### PR TITLE
Added gcloc to other counters section on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ cloc has many features that make it easy to use, thorough, extensible, and porta
 If cloc does not suit your needs here are other freely available counters to consider:
 
 *   [loc](https://github.com/cgag/loc/)
+*   [gcloc](https://github.com/JoaoDanielRufino/gcloc)
 *   [gocloc](https://github.com/hhatto/gocloc/)
 *   [Ohcount](https://github.com/blackducksoftware/ohcount/)
 *   [scc](https://github.com/boyter/scc/)


### PR DESCRIPTION
Signed-off-by: JoaoDanielRufino <joaodaniel0405@gmail.com>

- Added gcloc to other counters section on readme

[gcloc](https://github.com/JoaoDanielRufino/gcloc) is a cli written in Go developed by me inspired on cloc cli