### PR TITLE
Remove comments inside OCaml strings

### DIFF
--- a/cloc
+++ b/cloc
@@ -9534,6 +9534,7 @@ sub set_constants {                          # {{{1
                                 [ 'call_regexp_common'  , 'C++'    ],
                             ],
     'OCaml'              => [
+                                [ 'rm_comments_in_strings', '"', '(*', '*)', 1 ],
                                 [ 'remove_OCaml_comments',         ],
                             ],
     'OpenCL'             => [


### PR DESCRIPTION
This fixes #700 (as far as I can tell)