### PR TITLE
Fix incorrect parsing of config file

### DIFF
--- a/cloc
+++ b/cloc
@@ -13595,7 +13595,7 @@ sub load_from_config_file {                  # {{{1
         } elsif (!defined ${$rs_force_git}           and /^git/)                                              { ${$rs_force_git}          = 1;
         } elsif (!defined ${$rs_exclude_list_file}   and /^(?:exclude_list_file|exclude-list-file)(=|\s+)(.*?)$/)
                                                                    { ${$rs_exclude_list_file}  = $2;
-        } elsif (!defined ${$rs_v} and /(verbose|v)((=|\s+)(\d+))?/) {
+        } elsif (!defined ${$rs_v} and /^(verbose|v)((=|\s+)(\d+))?/) {
             if (!defined $4) { ${$rs_v} =  0; }
             else             { ${$rs_v} = $4; }
         } elsif (!$has_script_lang and /^(?:script_lang|script-lang)(=|\s+)(.*?)$/)         {


### PR DESCRIPTION
This fixes an issue with how the verbose flag is matched in config files. In the current release, it checks for "verbose" or "v" anywhere in the line, instead of only at the beginning of the line. This causes a config like "force-lang Objective-C,h" to match the verbose check instead (because of the v in Objective), if verbose has not already been specified. This changes that check to require v/verbose to be at the start of the line.