### PR TITLE
Add option for file count only

### DIFF
--- a/cloc
+++ b/cloc
@@ -387,6 +387,7 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
    --original-dir            [Only effective in combination with
                              --strip-comments]  Write the stripped files
                              to the same directory as the original files.
+   --only-count-files        Only count files by language.
    --read-binary-files       Process binary files in addition to text files.
                              This is usually a bad idea and should only be
                              attempted with text files that have embedded
@@ -776,6 +777,7 @@ my (
     $opt_summary_cutoff       ,
     $opt_skip_leading         ,
     $opt_no_recurse           ,
+    $opt_only_count_files     ,
    );
 
 my $getopt_success = GetOptions(             # {{{1
@@ -877,6 +879,7 @@ my $getopt_success = GetOptions(             # {{{1
    "summary_cutoff|summary-cutoff=s"         => \$opt_summary_cutoff      ,
    "skip_leading|skip-leading:s"             => \$opt_skip_leading        ,
    "no_recurse|no-recurse"                   => \$opt_no_recurse          ,
+   "only_count_files|only-count-files"       => \$opt_only_count_files    ,
   );
 # 1}}}
 $config_file = $opt_config_file if defined $opt_config_file;
@@ -2381,30 +2384,32 @@ sub count_files {                            # {{{1
             next;
         }
 
-        my ($all_line_count, $blank_count, $comment_count, $code_count);
-        if ($opt_use_sloccount and $Language{$file} =~ /^(C|C\+\+|XML|PHP|Pascal|Java)$/) {
-            chomp ($blank_count     = `grep -cv \"[^[:space:]]\" '$file'`);
-            chomp ($all_line_count  = `cat '$file' | wc -l`);
-            if      ($Language{$file} =~ /^(C|C\+\+)$/) {
-                $code_count = `cat '$file' | c_count      | head -n 1`;
-            } elsif ($Language{$file} eq "XML") {
-                $code_count = `cat '$file' | xml_count    | head -n 1`;
-            } elsif ($Language{$file} eq "PHP") {
-                $code_count = `cat '$file' | php_count    | head -n 1`;
-            } elsif ($Language{$file} eq "Pascal") {
-                $code_count = `cat '$file' | pascal_count | head -n 1`;
-            } elsif ($Language{$file} eq "Java") {
-                $code_count = `cat '$file' | java_count   | head -n 1`;
+        my ($all_line_count, $blank_count, $comment_count, $code_count) = (0, 0, 0, 0);
+        if (!$opt_only_count_files) {
+            if ($opt_use_sloccount and $Language{$file} =~ /^(C|C\+\+|XML|PHP|Pascal|Java)$/) {
+                chomp ($blank_count     = `grep -cv \"[^[:space:]]\" '$file'`);
+                chomp ($all_line_count  = `cat '$file' | wc -l`);
+                if      ($Language{$file} =~ /^(C|C\+\+)$/) {
+                    $code_count = `cat '$file' | c_count      | head -n 1`;
+                } elsif ($Language{$file} eq "XML") {
+                    $code_count = `cat '$file' | xml_count    | head -n 1`;
+                } elsif ($Language{$file} eq "PHP") {
+                    $code_count = `cat '$file' | php_count    | head -n 1`;
+                } elsif ($Language{$file} eq "Pascal") {
+                    $code_count = `cat '$file' | pascal_count | head -n 1`;
+                } elsif ($Language{$file} eq "Java") {
+                    $code_count = `cat '$file' | java_count   | head -n 1`;
+                } else {
+                    die "SLOCCount match failure: file=[$file] lang=[$Language{$file}]";
+                }
+                $code_count = substr($code_count, 0, -2);
+                $comment_count = $all_line_count - $code_count - $blank_count;
             } else {
-                die "SLOCCount match failure: file=[$file] lang=[$Language{$file}]";
+                ($all_line_count,
+                $blank_count   ,
+                $comment_count ,) = call_counter($file, $Language{$file}, \@Errors);
+                $code_count = $all_line_count - $blank_count - $comment_count;
             }
-            $code_count = substr($code_count, 0, -2);
-            $comment_count = $all_line_count - $code_count - $blank_count;
-        } else {
-            ($all_line_count,
-             $blank_count   ,
-             $comment_count ,) = call_counter($file, $Language{$file}, \@Errors);
-            $code_count = $all_line_count - $blank_count - $comment_count;
         }
 
         if ($opt_by_file) {


### PR DESCRIPTION
I needed something to only count files, classified by language. I like subroutines of `cloc` to identify languages but I was not satisfied by the performance drop caused by the line counting on big repositories (Which I do not need in my case). So I propose an option `--only-count-files` to skip line count.

Example on bash mirror repository https://github.com/bminor/bash :

```bash
❯ time ./cloc .
    1404 text files.
     587 unique files.                                          
     868 files ignored.

github.com/AlDanial/cloc v 1.97  T=0.73 s (801.4 files/s, 715967.8 lines/s)
---------------------------------------------------------------------------------------
Language                             files          blank        comment           code
---------------------------------------------------------------------------------------
PO File                                 39          25332          32315         170056
C                                      271          22627          21970         117193
HTML                                     3           4019             30          27309
Bourne Shell                            40           4513           3864          25686
Windows Module Definition               44           2676              9          15657
C/C++ Header                           113           2934           3591           8133
m4                                      40            663            829           7648
TeX                                      1            821           3462           6762
yacc                                     2            855            980           5411
Perl                                     2            535            834           4229
Text                                     4            363              0           1342
Bourne Again Shell                      16            177            327            769
Markdown                                 1             30              0            136
make                                     3             50             36            122
Assembly                                 2             11             20             48
awk                                      1              8             15             24
sed                                      2              0              0             16
TNSDL                                    3              0              0              5
---------------------------------------------------------------------------------------
SUM:                                   587          65614          68282         390546
---------------------------------------------------------------------------------------

real    0m0,821s
user    0m0,762s
sys     0m0,059s

❯ time ./cloc --only-count-files .
    1404 text files.
     587 unique files.                                          
     868 files ignored.

github.com/AlDanial/cloc v 1.97  T=0.05 s (10684.4 files/s, 0.0 lines/s)
---------------------------------------------------------------------------------------
Language                             files          blank        comment           code
---------------------------------------------------------------------------------------
Assembly                                 2              0              0              0
Bourne Again Shell                      16              0              0              0
Bourne Shell                            40              0              0              0
C                                      271              0              0              0
C/C++ Header                           113              0              0              0
HTML                                     3              0              0              0
Markdown                                 1              0              0              0
PO File                                 39              0              0              0
Perl                                     2              0              0              0
TNSDL                                    3              0              0              0
TeX                                      1              0              0              0
Text                                     4              0              0              0
Windows Module Definition               44              0              0              0
awk                                      1              0              0              0
m4                                      40              0              0              0
make                                     3              0              0              0
sed                                      2              0              0              0
yacc                                     2              0              0              0
---------------------------------------------------------------------------------------
SUM:                                   587              0              0              0
---------------------------------------------------------------------------------------

real    0m0,135s
user    0m0,109s
sys     0m0,024s
```