### PR TITLE
Count lines in TLA+ and PlusCal files

### DIFF
--- a/Unix/cloc
+++ b/Unix/cloc
@@ -7633,6 +7633,64 @@ sub remove_OCaml_comments {                  # {{{1
     print "<- remove_OCaml_comments\n" if $opt_v > 2;
     return @save_lines;
 } # 1}}}
+sub remove_TLAPlus_generated_code {          # {{{1
+    my ($ra_lines, ) = @_;
+    # If --no-autogen, remove code created by the PlusCal translator.
+    return @{$ra_lines} if !$opt_no_autogen;
+    return remove_between_regex($ra_lines, '^\\\\\\* BEGIN TRANSLATION\b', '^\\\\\\* END TRANSLATION\b');
+} # 1}}}
+sub remove_TLAPlus_comments {                # {{{1
+    my ($ra_lines, ) = @_;
+    # TLA+ block comments are like OCaml comments (remove_OCaml_comments).
+    # However, TLA+ comments may contain PlusCal code, and we must consider the
+    # PlusCal code as code, not comments.
+
+    print "-> remove_TLAPlus_comments\n" if $opt_v > 2;
+
+    my @save_lines = ();
+    my $in_comment = 0;        # counter to depth of nested (* *) comments
+    my $in_pluscal_head = 0;   # whether we saw the start of PlusCal code
+    my $in_pluscal_block = 0;  # counter to depth of nested { } blocks
+    my $saved_in_comment = 0;  # $in_comment before we entered PlusCal code
+    foreach my $L (@{$ra_lines}) {
+        next if $L =~ /^\s*$/;
+        # make an array of interesting tokens we need to act upon
+        my $clean_line = ""; # ie, free of comments
+        my @tokens = split(/(\(\*|\*\)|".*?"|[{}]|--fair\b|--algorithm|PlusCal options)/, $L);
+        foreach my $t (@tokens) {
+            next unless $t;
+            if      ($t eq "(*") {
+                ++$in_comment;
+            } elsif ($t eq "*)") {
+                --$in_comment;
+            } elsif ($t eq "{" && $in_pluscal_head) {
+                # start block matching when we see '{' in '--algorithm NAME {'
+                $in_pluscal_head = 0;
+                $in_pluscal_block = 1;
+                $saved_in_comment = $in_comment;
+                $in_comment = 0;
+                $clean_line .= $t;
+            } elsif ($t eq "{" && $in_pluscal_block && !$in_comment) {
+                ++$in_pluscal_block;
+                $clean_line .= $t;
+            } elsif ($t eq "}" && $in_pluscal_block && !$in_comment) {
+                --$in_pluscal_block;
+                if ($in_pluscal_block == 0) {
+                    $in_comment = $saved_in_comment;
+                }
+                $clean_line .= $t;
+            } elsif ($t eq "--fair" || $t eq "--algorithm") {
+                $in_pluscal_head = 1;
+                $clean_line .= $t;
+            } elsif (!$in_comment || $in_pluscal_head || $in_pluscal_block || $t eq "PlusCal options") {
+                $clean_line .= $t;
+            }
+        }
+        push @save_lines, $clean_line if $clean_line;
+    }
+    print "<- remove_TLAPlus_comments\n" if $opt_v > 2;
+    return @save_lines;
+} # 1}}}
 sub remove_slim_block {                      # {{{1
     # slim comments start with /
     # followed by indented text on subsequent lines.
@@ -8640,6 +8698,7 @@ sub set_constants {                          # {{{1
             'tres'        => 'Godot Resource'        ,
             'tscn'        => 'Godot Scene'           ,
             'thrift'      => 'Thrift'                ,
+            'tla'         => 'TLA+'                  ,
             'tpl'         => 'Smarty'                ,
             'trigger'     => 'Apex Trigger'          ,
             'ttcn'        => 'TTCN'                  ,
@@ -10205,6 +10264,11 @@ sub set_constants {                          # {{{1
     'Text'               => [
                                 [ 'remove_matches'      , '^\s*$'  ],
                             ],
+    'TLA+'               => [
+                                [ 'remove_TLAPlus_generated_code'                 ],
+                                [ 'remove_matches'               , '^\\s*\\\\\\*' ],
+                                [ 'remove_TLAPlus_comments'                       ],
+                            ],
     'Thrift'             => [
                                 [ 'rm_comments_in_strings', '"', '/*', '*/' ],
                                 [ 'rm_comments_in_strings', '"', '//', '' ],
@@ -10976,6 +11040,7 @@ sub set_constants {                          # {{{1
     'TeX'                          =>   1.50,
     'Text'                         =>   0.50,
     'Thrift'                       =>   2.50,
+    'TLA+'                         =>   1.00,
     'Titanium Style Sheet'         =>   2.00,
     'TOML'                         =>   2.76,
     'Twig'                         =>   2.00,

--- a/Unix/t/00_C.t
+++ b/Unix/t/00_C.t
@@ -1087,6 +1087,21 @@ my @Tests = (
                     'args' => '../tests/inputs/DocTest.thrift',
                 },
                 {
+                    'name' => 'TLA+',
+                    'ref'  => '../tests/outputs/TLAExample.tla.yaml',
+                    'args' => '../tests/inputs/TLAExample.tla',
+                },
+                {
+                    'name' => 'TLA+/PlusCal',
+                    'ref'  => '../tests/outputs/PlusCalExample.tla.yaml',
+                    'args' => '../tests/inputs/PlusCalExample.tla',
+                },
+                {
+                    'name' => 'TLA+/PlusCal --no-autogen',
+                    'ref'  => '../tests/outputs/PlusCalExample-no-autogen.tla.yaml',
+                    'args' => '--no-autogen ../tests/inputs/PlusCalExample.tla',
+                },
+                {
                     'name' => 'TOML',
                     'ref'  => '../tests/outputs/toml_example.toml.yaml',
                     'args' => '../tests/inputs/toml_example.toml',

--- a/cloc
+++ b/cloc
@@ -7648,6 +7648,64 @@ sub remove_OCaml_comments {                  # {{{1
     print "<- remove_OCaml_comments\n" if $opt_v > 2;
     return @save_lines;
 } # 1}}}
+sub remove_TLAPlus_generated_code {          # {{{1
+    my ($ra_lines, ) = @_;
+    # If --no-autogen, remove code created by the PlusCal translator.
+    return @{$ra_lines} if !$opt_no_autogen;
+    return remove_between_regex($ra_lines, '^\\\\\\* BEGIN TRANSLATION\b', '^\\\\\\* END TRANSLATION\b');
+} # 1}}}
+sub remove_TLAPlus_comments {                # {{{1
+    my ($ra_lines, ) = @_;
+    # TLA+ block comments are like OCaml comments (remove_OCaml_comments).
+    # However, TLA+ comments may contain PlusCal code, and we must consider the
+    # PlusCal code as code, not comments.
+
+    print "-> remove_TLAPlus_comments\n" if $opt_v > 2;
+
+    my @save_lines = ();
+    my $in_comment = 0;        # counter to depth of nested (* *) comments
+    my $in_pluscal_head = 0;   # whether we saw the start of PlusCal code
+    my $in_pluscal_block = 0;  # counter to depth of nested { } blocks
+    my $saved_in_comment = 0;  # $in_comment before we entered PlusCal code
+    foreach my $L (@{$ra_lines}) {
+        next if $L =~ /^\s*$/;
+        # make an array of interesting tokens we need to act upon
+        my $clean_line = ""; # ie, free of comments
+        my @tokens = split(/(\(\*|\*\)|".*?"|[{}]|--fair\b|--algorithm|PlusCal options)/, $L);
+        foreach my $t (@tokens) {
+            next unless $t;
+            if      ($t eq "(*") {
+                ++$in_comment;
+            } elsif ($t eq "*)") {
+                --$in_comment;
+            } elsif ($t eq "{" && $in_pluscal_head) {
+                # start block matching when we see '{' in '--algorithm NAME {'
+                $in_pluscal_head = 0;
+                $in_pluscal_block = 1;
+                $saved_in_comment = $in_comment;
+                $in_comment = 0;
+                $clean_line .= $t;
+            } elsif ($t eq "{" && $in_pluscal_block && !$in_comment) {
+                ++$in_pluscal_block;
+                $clean_line .= $t;
+            } elsif ($t eq "}" && $in_pluscal_block && !$in_comment) {
+                --$in_pluscal_block;
+                if ($in_pluscal_block == 0) {
+                    $in_comment = $saved_in_comment;
+                }
+                $clean_line .= $t;
+            } elsif ($t eq "--fair" || $t eq "--algorithm") {
+                $in_pluscal_head = 1;
+                $clean_line .= $t;
+            } elsif (!$in_comment || $in_pluscal_head || $in_pluscal_block || $t eq "PlusCal options") {
+                $clean_line .= $t;
+            }
+        }
+        push @save_lines, $clean_line if $clean_line;
+    }
+    print "<- remove_TLAPlus_comments\n" if $opt_v > 2;
+    return @save_lines;
+} # 1}}}
 sub remove_slim_block {                      # {{{1
     # slim comments start with /
     # followed by indented text on subsequent lines.
@@ -8655,6 +8713,7 @@ sub set_constants {                          # {{{1
             'tres'        => 'Godot Resource'        ,
             'tscn'        => 'Godot Scene'           ,
             'thrift'      => 'Thrift'                ,
+            'tla'         => 'TLA+'                  ,
             'tpl'         => 'Smarty'                ,
             'trigger'     => 'Apex Trigger'          ,
             'ttcn'        => 'TTCN'                  ,
@@ -10220,6 +10279,11 @@ sub set_constants {                          # {{{1
     'Text'               => [
                                 [ 'remove_matches'      , '^\s*$'  ],
                             ],
+    'TLA+'               => [
+                                [ 'remove_TLAPlus_generated_code'                 ],
+                                [ 'remove_matches'               , '^\\s*\\\\\\*' ],
+                                [ 'remove_TLAPlus_comments'                       ],
+                            ],
     'Thrift'             => [
                                 [ 'rm_comments_in_strings', '"', '/*', '*/' ],
                                 [ 'rm_comments_in_strings', '"', '//', '' ],
@@ -10991,6 +11055,7 @@ sub set_constants {                          # {{{1
     'TeX'                          =>   1.50,
     'Text'                         =>   0.50,
     'Thrift'                       =>   2.50,
+    'TLA+'                         =>   1.00,
     'Titanium Style Sheet'         =>   2.00,
     'TOML'                         =>   2.76,
     'Twig'                         =>   2.00,

--- a/tests/inputs/PlusCalExample.tla
+++ b/tests/inputs/PlusCalExample.tla
@@ -1,0 +1,53 @@
+---- MODULE PlusCalExample ----
+(* TLA+/PlusCal example program. *)
+(* Multi-line
+   (* nested *)
+   comment *)
+\* Single-line comment
+
+\* The code below appears to be a TLA+ comment but is PlusCal code which should
+\* always be line-counted.
+\* Grammar rules for PlusCal are specified in appendices A and C of A PlusCal
+\* User's Manual: https://lamport.azurewebsites.net/tla/c-manual.pdf
+(*
+PlusCal options (-sf)
+--algorithm Example {
+  process (A = 0) {
+    Start: skip;
+  }
+}
+This is a comment line.
+*)
+
+\* The code between BEGIN( )TRANSLATION and END( )TRANSLATION should be
+\* line-counted as generated code.
+\* BEGIN TRANSLATION (chksum(pcal) = "7bf2389f" /\ chksum(tla) = "dd78b4d4")
+VARIABLE pc
+
+vars == << pc >>
+
+ProcSet == {0}
+
+Init == /\ pc = [self \in ProcSet |-> "Start"]
+
+Start == /\ pc[0] = "Start"
+         /\ TRUE
+         /\ pc' = [pc EXCEPT ![0] = "Done"]
+
+A == Start
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == A
+           \/ Terminating
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ SF_vars(A)
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+====

--- a/tests/inputs/TLAExample.tla
+++ b/tests/inputs/TLAExample.tla
@@ -1,0 +1,13 @@
+---- MODULE TLAExample ----
+(* TLA+ example program. *)
+(* Multi-line
+   (* nested *)
+   comment *)
+\* Single-line comment
+
+VARIABLES tlaIsCool
+
+Init == tlaIsCool = TRUE
+
+Next == tlaIsCool = TRUE /\ tlaIsCool' = TRUE
+====

--- a/tests/outputs/PlusCalExample-no-autogen.tla.yaml
+++ b/tests/outputs/PlusCalExample-no-autogen.tla.yaml
@@ -1,0 +1,11 @@
+---
+'TLA+':
+  nFiles: 1
+  blank: 13
+  comment: 32
+  code: 8
+SUM:
+  nFiles: 1
+  blank: 13
+  comment: 32
+  code: 8

--- a/tests/outputs/PlusCalExample.tla.yaml
+++ b/tests/outputs/PlusCalExample.tla.yaml
@@ -1,0 +1,11 @@
+---
+'TLA+':
+  nFiles: 1
+  blank: 13
+  comment: 17
+  code: 23
+SUM:
+  nFiles: 1
+  blank: 13
+  comment: 17
+  code: 23

--- a/tests/outputs/TLAExample.tla.yaml
+++ b/tests/outputs/TLAExample.tla.yaml
@@ -1,0 +1,11 @@
+---
+'TLA+':
+  nFiles: 1
+  blank: 3
+  comment: 5
+  code: 5
+SUM:
+  nFiles: 1
+  blank: 3
+  comment: 5
+  code: 5


### PR DESCRIPTION
Recognize .tla files as TLA+ files. Parse PlusCal directives inside TLA+ comments and, if --no-autogen is specified, ignore the PlusCal translator's output within TLA+ files.