### PR TITLE
Fix installing dependencies via cpan in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,43 @@
 # Dockerfile by Sébastien HOUZÉ, https://github.com/shouze
-FROM perl:slim AS base
+FROM perl:slim AS builder
 
 RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    git \
-    unzip \
     dos2unix \
- && rm -rf /var/lib/apt/lists/*
+    gcc
 
 #Install all dependencies
-# 2024-01-19 cpanm command has been failing -- no explanation
-#RUN cpanm \
-#      Algorithm::Diff \
-#      Digest::MD5 \
-#      Parallel::ForkManager \
-#      Regexp::Common \
-# && rm -rf $HOME/.cpanm
+RUN cpanm \
+      Algorithm::Diff \
+      Digest::MD5 \
+      Parallel::ForkManager \
+      Regexp::Common
 
 #Copy source code
 COPY cloc /usr/src/
 RUN find /usr/src/ -type f -exec dos2unix {} \;
 
+FROM perl:slim AS base
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    git \
+    unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+#Copy dependencies and source prepared in base image
+COPY --from=builder /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=builder /usr/src/ /usr/src/
+
 ####################
 FROM base AS test
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates
 
 #Copy test code
 COPY .git /usr/src/.git


### PR DESCRIPTION
I did some debugging on why the cpan command was failing. It turns out it was because installing Digest::MD5 relies on a c compiler being present. This resolves the issue by installing gcc. In order to not bloat the image, I've introduced an additional stage purely for the build process (installing dependencies, etc). This also means dos2unix is not included in the final stage, and ca-certificates has also been moved to the test stage (the only stage that actually needs it)