### PR TITLE
Fix CI not actually running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
         IMAGE_TAG: ${{ github.sha }}
       run: |
         # Build a docker container to run tests
-        docker build .
+        docker build . --target test


### PR DESCRIPTION
Since Docker BuildKit became the default build mechanism in Docker, multistage Dockerfiles no longer automatically build all stages. This change forces the test stage to actually run.

Note that this requires #824 to be merged, as currently cpan fails to run due to perl dependencies not being installed into the container