### PR TITLE
fix: works when ran through a symlink

### DIFF
--- a/cloc
+++ b/cloc
@@ -136,6 +136,19 @@ if ($ON_WINDOWS and $ENV{'SHELL'}) {
     }
 }
 
+use Cwd "abs_path";
+use File::Spec;
+my $exec_path = abs_path($0);
+# Fix for issues when runing cloc through a symlink on Windows
+# e.g. : it have been installed with Winget
+# See https://github.com/AlDanial/cloc/issues/849
+if ($ON_WINDOWS) {
+    if (-l $0) {
+        $exec_path = abs_path(readlink($0));
+    }
+    $0 = $exec_path;
+}
+
 my $HAVE_Win32_Long_Path = 0;
 # Win32::LongPath is an optional dependency that when available on
 # Windows will be used to support reading files past the 255 char


### PR DESCRIPTION
closes https://github.com/AlDanial/cloc/issues/849  
  
I'll let you bump the version and create the executables  
Successfully tested on Windows :  
![image](https://github.com/user-attachments/assets/04147825-5e18-45cd-8c4f-1119308bf8de)  
![image](https://github.com/user-attachments/assets/83f8d856-6616-4c19-b77c-8cfe744e01ce)
  
I only tried the built windows executable, but this shouldn't affect builds for other distros.  
Also my knowledge in Perl is really the bare minimum so there could be a better way to write it or maybe some imports are duplicated. All I know is that it works :)