### PR TITLE
Separate consideration of Elixir from Elixir Script

### DIFF
--- a/cloc
+++ b/cloc
@@ -8852,7 +8852,7 @@ sub set_constants {                          # {{{1
             'eex'         => 'EEx'                   ,
             'el'          => 'Lisp'                  ,
             'elm'         => 'Elm'                   ,
-            'exs'         => 'Elixir'                ,
+            'exs'         => 'Elixir Script'         ,
             'ex'          => 'Elixir'                ,
             'ecr'         => 'Embedded Crystal'      ,
             'ejs'         => 'EJS'                   ,


### PR DESCRIPTION
End-users have different considerations for Elixir(.ex) and Elixir Script(.exs) when analyzing cloc output, they should be counted separately.

For example if you want to know how much pure server-side code (Elixir) vs. how much server-side rendered client-side code (LiveView in Elixir Script), you need two different code counts.