### PR TITLE
[fix] Add standard Jenkinsfile filename to be recognized as Groovy files

### DIFF
--- a/cloc
+++ b/cloc
@@ -9775,6 +9775,8 @@ sub set_constants {                          # {{{1
             'dockerfile.m4'     => 'Dockerfile'         ,
             'dockerfile.cmake'  => 'Dockerfile'         ,
             'Containerfile'     => 'Containerfile'      ,
+            'Jenkinsfile'       => 'Groovy'             ,
+            'jenkinsfile'       => 'Groovy'             ,
             );
 # 1}}}
 %{$rh_Language_by_Prefix}     = (            # {{{1


### PR DESCRIPTION
**Describe the bug**  
Files named `Jenkinsfile` or `jenkinsfile` are standard but not recognized as Groovy. Only `.jenkinsfile` are.

**cloc; OS; OS version**  
- cloc version: 2.04  
- OS: Windows or MacOS
- OS version: Windows 11 or  MacOS Sequoia 15.3.2

**To Reproduce**  
1. Create a file named `jenkinsfile` or `Jenkinsfile`.  
2. Run cloc → not recognized as Groovy.  
3. Rename to `.jenkinsfile` → recognized as Groovy.  

**Expected result**  
`Jenkinsfile` and `jenkinsfile` should be recognized as Groovy.

**Additional context**  
Current Groovy definition uses `extension jenkinsfile`. Since `Jenkinsfile` has no extension, it is not matched.

**Proposed solution**  
Keep (for retrocompatibility):  
```
extension jenkinsfile
```
Add:  
```
filename Jenkinsfile
filename jenkinsfile
```

