### PR TITLE
version 2.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,8 @@ Usage: cloc [options] &lt;file(s)/dir(s)/git hash(es)&gt; | &lt;set 1&gt; &lt;se
                              Setting &lt;VCS&gt; to 'auto' selects between 'git'
                              and 'svn' (or neither) depending on the presence
                              of a .git or .svn subdirectory below the directory
-                             where cloc is invoked.
+                             where cloc is invoked.  --files-from is a synonym
+                             for --vcs.
    --unicode                 Check binary files to see if they contain Unicode
                              expanded ASCII text.  This causes performance to
                              drop noticeably.
@@ -1036,6 +1037,8 @@ Usage: cloc [options] &lt;file(s)/dir(s)/git hash(es)&gt; | &lt;set 1&gt; &lt;se
                              (JSON) formatted output.
    --md                      Write the results as Markdown-formatted text.
    --out=&lt;file&gt;              Synonym for --report-file=&lt;file&gt;.
+   --percent                 Show counts as percentages of sums for each column.
+                             Same as '--by-percent t'.
    --progress-rate=&lt;n&gt;       Show progress update after every &lt;n&gt; files are
                              processed (default &lt;n&gt;=100).  Set &lt;n&gt; to 0 to
                              suppress progress output (useful when redirecting
@@ -1056,6 +1059,12 @@ Usage: cloc [options] &lt;file(s)/dir(s)/git hash(es)&gt; | &lt;set 1&gt; &lt;se
                              'Oracle' and 'Named_Columns'.
    --sum-one                 For plain text reports, show the SUM: output line
                              even if only one input file is processed.
+   --thousands-delimiter=&lt;C&gt; Divides numbers with many digits (i.e. numbers
+                             over 999) into groups using the character <C> as
+                             delimiter (e.g. for <C> = '.': 12345 -> 12.345).
+                             Only works with the '--fmt' option.
+                             Sample values: '.', ',', '_', ' '
+                             Synonym:  --ksep
    --xml                     Write the results in XML.
    --xsl=&lt;file&gt;              Reference &lt;file&gt; as an XSL stylesheet within
                              the XML output.  If &lt;file&gt; is 1 (numeric one),

--- a/Unix/NEWS
+++ b/Unix/NEWS
@@ -1,3 +1,56 @@
+                Release Notes for cloc version 2.06
+                   https://github.com/AlDanial/cloc
+                             June 22, 2025
+
+New Languages and File Types:
+    o Cangjie
+    o Elixir Script
+    o Fortran 2003
+    o Jsonnet
+    o Nextflow
+    o Nushell
+    o Org Mode
+    o Rego
+    o UXML, USS (Unity)
+
+Updates:
+    o First attempt at using Github Actions to package a release
+      including making a Windows executable that works with
+      symlinks as used by winget
+    o Add column headers for --show-lang and --show-ext output
+    o Remove '->' separator in --show-ext output
+    o Remove leading blank space for --fmt output written to STDOUT
+    o New switch --files-from as a synonym for --vcs
+    o New switch --ksep/--thousands-delimiter to show a separator (default
+      is a comma) between thousands in output counts
+    o Change sequence of Python language filters so that docstrings are
+      handled before #
+    o Jenkinsfile now recognized as Groovy
+    o Improve Windows/Unix path conflicts when using --git --diff in
+      git-bash terminal
+    o New switch --percent as a shortcut to '--by-percent t' to show
+      percentage of totals in blank, comment, code columns
+    o Add backtick and C++ style comment support for Svelte
+    o Write results in multiple formats if multiple output format
+      switches are given (for example --json --yaml --xml)
+
+Bug fixes:
+    o Remove file 'irregular"file2.md' from the test suite as filenames
+      with embedded double quotes are illegal in Windows and cause git
+      pull problems (among other issues).  This file is created dynamically
+      during testing on non-Windows operating systems.
+    o On Windows use zip format instead of tar for the 'git archive' command
+      used when running with --git --diff
+    o Remove duplicate "percent" entry in options handling
+    o Support --exclude-lang in --diff mode
+    o Fix --exclude-lang option when used in diff mode and when all files
+      are additions or deletions
+    o On Windows, remove temporary "SCALAR(0x..)" files created when
+      using --fmt
+    o Handle --by-file for JSON and YAML outputs with single and double
+      quotes in file names
+
+============================================================================
                 Release Notes for cloc version 2.04
                    https://github.com/AlDanial/cloc
                              Jan. 31, 2025

--- a/Unix/cloc
+++ b/Unix/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.05";  # odd number == beta; even number == stable
+my $VERSION = "2.06";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1
@@ -2399,6 +2399,12 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              'Oracle' and 'Named_Columns'.
    --sum-one                 For plain text reports, show the SUM: output line
                              even if only one input file is processed.
+   --thousands-delimiter=<C> Divides numbers with many digits (i.e. numbers
+                             over 999) into groups using the character <C> as
+                             delimiter (e.g. for <C> = '.': 12345 -> 12.345).
+                             Only works with the '--fmt' option.
+                             Sample values: '.', ',', '_', ' '
+                             Synonym:  --ksep
    --xml                     Write the results in XML.
    --xsl=<file>              Reference <file> as an XSL stylesheet within
                              the XML output.  If <file> is 1 (numeric one),
@@ -2406,12 +2412,6 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              cloc-diff.xsl if --diff is also given).
                              This switch forces --xml on.
    --yaml                    Write the results in YAML.
-   --thousands-delimiter=<C> Divides numbers with many digits (i.e. numbers
-                             over 999) into groups using the character <C> as
-                             delimiter (e.g. for <C> = '.': 12345 -> 12.345).
-                             Only works with the '--fmt' option.
-                             Sample values: '.', ',', '_', ' '
-                             Synonym:  --ksep
 ";
 }
 # 1}}}

--- a/cloc
+++ b/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.05";  # odd number == beta; even number == stable
+my $VERSION = "2.06";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1
@@ -2391,6 +2391,12 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              'Oracle' and 'Named_Columns'.
    --sum-one                 For plain text reports, show the SUM: output line
                              even if only one input file is processed.
+   --thousands-delimiter=<C> Divides numbers with many digits (i.e. numbers
+                             over 999) into groups using the character <C> as
+                             delimiter (e.g. for <C> = '.': 12345 -> 12.345).
+                             Only works with the '--fmt' option.
+                             Sample values: '.', ',', '_', ' '
+                             Synonym:  --ksep
    --xml                     Write the results in XML.
    --xsl=<file>              Reference <file> as an XSL stylesheet within
                              the XML output.  If <file> is 1 (numeric one),
@@ -2398,12 +2404,6 @@ Usage: $script [options] <file(s)/dir(s)/git hash(es)> | <set 1> <set 2> | <repo
                              cloc-diff.xsl if --diff is also given).
                              This switch forces --xml on.
    --yaml                    Write the results in YAML.
-   --thousands-delimiter=<C> Divides numbers with many digits (i.e. numbers
-                             over 999) into groups using the character <C> as
-                             delimiter (e.g. for <C> = '.': 12345 -> 12.345).
-                             Only works with the '--fmt' option.
-                             Sample values: '.', ',', '_', ' '
-                             Synonym:  --ksep
 ";
 }
 # 1}}}


### PR DESCRIPTION
New Languages and File Types:
    o Cangjie
    o Elixir Script
    o Fortran 2003
    o Jsonnet
    o Nextflow
    o Nushell
    o Org Mode
    o Rego
    o UXML, USS (Unity)

Updates:
    o First attempt at using Github Actions to package a release including making a Windows executable that works with symlinks as used by winget
    o Add column headers for `--show-lang` and `--show-ext` output
    o Remove '->' separator in `--show-ext` output
    o Remove leading blank space for `--fmt` output written to STDOUT
    o New switch `--files-from` as a synonym for `--vcs`
    o New switch `--ksep`/`--thousands-delimiter` to show a separator (default is a comma) between thousands in output counts
    o Change sequence of Python language filters so that docstrings are handled before `#`
    o Jenkinsfile now recognized as Groovy
    o Improve Windows/Unix path conflicts when using `--git --diff` in git-bash terminal
    o New switch `--percent` as a shortcut to `--by-percent t` to show percentage of totals in blank, comment, code columns
    o Add backtick and C++ style comment support for Svelte
    o Write results in multiple formats if multiple output format switches are given (for example `--json`,  `--yaml`, `--xml`)

Bug fixes:
    o Remove file `irregular"file2.md` from the test suite as filenames with embedded double quotes are illegal in Windows and cause git pull problems (among other issues).  This file is created dynamically during testing on non-Windows operating systems.
    o On Windows use zip format instead of tar for the `git archive` command used when running with `--git --diff`
    o Remove duplicate "percent" entry in options handling
    o Support `--exclude-lang` in `--diff` mode
    o Fix `--exclude-lang` option when used in diff mode and when all files are additions or deletions
    o On Windows, remove temporary "SCALAR(0x..)" files created when using `--fmt`
    o Handle `--by-file` for JSON and YAML outputs with single and double quotes in file names