### PR TITLE
Add support for DAML

### DIFF
--- a/cloc
+++ b/cloc
@@ -8975,6 +8975,7 @@ sub set_constants {                          # {{{1
 # bash or sh scripts
             'dfy'         => 'Dafny'                 ,
             'da'          => 'DAL'                   ,
+            'daml'        => 'DAML'                  ,
             'dart'        => 'Dart'                  ,
             'dsc'         => 'DenizenScript'         ,
             'derw'        => 'Derw'                  ,
@@ -10250,6 +10251,9 @@ sub set_constants {                          # {{{1
                             ],
     'DAL'                => [
                                 [ 'remove_between_general', '[', ']', ],
+                            ],
+    'DAML'               => [
+                                [ 'remove_haskell_comments', '>filename<' ],
                             ],
     'Dart'               => [
                                 [ 'rm_comments_in_strings', '"', '/*', '*/' ],
@@ -12047,6 +12051,7 @@ sub set_constants {                          # {{{1
     'D'                            =>   1.70,
     'Dafny'                        =>   3.00,
     'DAL'                          =>   1.50,
+    'DAML'                         =>   2.11,
     'Dart'                         =>   2.00,
     'DenizenScript'                =>   1.00,
     'Delphi Form'                  =>   2.00,
@@ -17055,6 +17060,7 @@ my @generic = (
 my @plain_or_nested = (
    [Caml         =>  undef,       "(*"  => "*)"],
    [Dylan        =>  "//",        "/*"  => "*/"],
+   [DAML         =>  "-{2,}",     "{-"  => "-}"],
    [Haskell      =>  "-{2,}",     "{-"  => "-}"],
    [Hugo         =>  "!(?!\\\\)", "!\\" => "\\!"],
    [SLIDE        =>  "#",         "(*"  => "*)"],


### PR DESCRIPTION
DAML is a smart contract language used by the Canton ledger (Digital Asset).
It uses Haskell-style syntax and identical comment markers (`--` line comments,
`{- -}` nested block comments, `{-# #-}` pragmas), so this reuses the existing
`remove_haskell_comments` handler.

Reference: https://docs.daml.com/
