### PR TITLE
Fix wscript support

### DIFF
--- a/Unix/cloc
+++ b/Unix/cloc
@@ -9407,7 +9407,6 @@ sub set_constants {                          # {{{1
             'psql'        => 'SQL'                   ,
             'xpy'         => 'Python'                ,
             'wsgi'        => 'Python'                ,
-            'wscript'     => 'Python'                ,
             'workspace'   => 'Python'                ,
             'tac'         => 'Python'                ,
             'snakefile'   => 'Python'                ,
@@ -9928,6 +9927,7 @@ sub set_constants {                          # {{{1
             'Containerfile'     => 'Containerfile'      ,
             'Jenkinsfile'       => 'Groovy'             ,
             'jenkinsfile'       => 'Groovy'             ,
+            'wscript'           => 'Python'             ,
             );
 # 1}}}
 %{$rh_Language_by_Prefix}     = (            # {{{1

--- a/cloc
+++ b/cloc
@@ -9399,7 +9399,6 @@ sub set_constants {                          # {{{1
             'psql'        => 'SQL'                   ,
             'xpy'         => 'Python'                ,
             'wsgi'        => 'Python'                ,
-            'wscript'     => 'Python'                ,
             'workspace'   => 'Python'                ,
             'tac'         => 'Python'                ,
             'snakefile'   => 'Python'                ,
@@ -9920,6 +9919,7 @@ sub set_constants {                          # {{{1
             'Containerfile'     => 'Containerfile'      ,
             'Jenkinsfile'       => 'Groovy'             ,
             'jenkinsfile'       => 'Groovy'             ,
+            'wscript'           => 'Python'             ,
             );
 # 1}}}
 %{$rh_Language_by_Prefix}     = (            # {{{1


### PR DESCRIPTION
The waf build system uses "wscript" files, whereby "wscript" is the actual file name and not an extension ("foo.wscript" is not supported). wscript files are normal Python files.

See also https://waf.io/book/#_waf_commands_and_usage

I'm unsure if wscript should be *moved* from Language_by_Extension to Language_by_File_Type vs just *added* to Language_by_Extension, because e.g. Makefile and other names are listed in both places too.