### PR TITLE
Fix citation references in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Latest release:  v2.08 (Jan. 24, 2026)
 
 [![Version](https://img.shields.io/badge/version-2.08-blue.svg)](https://github.com/AlDanial/cloc)
 [![Contributors](https://img.shields.io/github/contributors/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/graphs/contributors)
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.42029482.svg)](https://doi.org/10.5281/zenodo.42029482)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.5760076.svg)](https://doi.org/10.5281/zenodo.5760076)
 [![Forks](https://img.shields.io/github/forks/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/network/members)
 [![Downloads](https://img.shields.io/github/downloads/AlDanial/cloc/total.svg)]()
 

--- a/README.md
+++ b/README.md
@@ -3170,12 +3170,12 @@ Please use the following bibtex entry to cite cloc in a publication:
 @software{adanial_cloc,
   author       = {Albert Danial},
   title        = {cloc: v2.08},
-  month        = dec,
+  month        = jan,
   year         = 2026,
   publisher    = {Zenodo},
   version      = {v2.08},
-  doi          = {10.5281/zenodo.5760077},
-  url          = {https://doi.org/10.5281/zenodo.5760077}
+  doi          = {10.5281/zenodo.18364352},
+  url          = {https://doi.org/10.5281/zenodo.18364352}
 }
 ```
 


### PR DESCRIPTION
1.  Change the Zenodo badge in the README to link to the [Concept DOI](https://zenodo.org/help/versioning#:~:text=The%20Concept%20DOI%20resolves%20to%20the%20landing%20page%20of%20the%20latest%20version%20of%20your%20record%2E), which will always resolve to the latest version.

2.  Fix incorrect DOI and release month for v2.08 of the bibtex entry section of the README.