### PR TITLE
Fix --fmt with --by-percent producing zeros and warnings (#967)

### DIFF
--- a/Unix/t/01_opts.t
+++ b/Unix/t/01_opts.t
@@ -982,6 +982,26 @@ foreach my $t (@Tests) {
 
     is_deeply(\%ref, \%this, $t->{'name'} . " results match");
 }
+
+# Issue #967: --fmt with --by-percent emitted "Use of uninitialized value"
+# warnings and zeroed counts because the JSON it round-trips uses
+# blank_pct/comment_pct/code_pct keys that print_format_n didn't read.
+{
+    chdir("../tests/inputs/dd");
+    my $stderr_file = "$work_dir/by_percent_fmt_stderr.txt";
+    my $stdout_file = "$work_dir/by_percent_fmt_stdout.txt";
+    my $cmd = "$cloc --fmt=4 --by-percent=cm . > $stdout_file 2> $stderr_file";
+    system($cmd);
+    chdir($work_dir);
+    my $stderr = do { local (@ARGV, $/) = $stderr_file; <> } // "";
+    my $stdout = do { local (@ARGV, $/) = $stdout_file; <> } // "";
+    unlink $stderr_file, $stdout_file unless $Verbose;
+    unlike($stderr, qr/Use of uninitialized value/,
+           "issue #967: --fmt=4 --by-percent=cm emits no uninitialized warnings");
+    like($stdout, qr/\d+\.\d+/,
+         "issue #967: --fmt=4 --by-percent=cm produces non-zero output");
+}
+
 done_testing();
 print "Finished testing $cloc\n";
 

--- a/Unix/t/01_opts.t
+++ b/Unix/t/01_opts.t
@@ -986,6 +986,8 @@ foreach my $t (@Tests) {
 # Issue #967: --fmt with --by-percent emitted "Use of uninitialized value"
 # warnings and zeroed counts because the JSON it round-trips uses
 # blank_pct/comment_pct/code_pct keys that print_format_n didn't read.
+# A related defect: --by-percent=cm divided by zero whenever any entry
+# had code+comment == 0 (e.g. tests/inputs/issues/644/UInt8.cs).
 {
     chdir("../tests/inputs/dd");
     my $stderr_file = "$work_dir/by_percent_fmt_stderr.txt";
@@ -1000,6 +1002,23 @@ foreach my $t (@Tests) {
            "issue #967: --fmt=4 --by-percent=cm emits no uninitialized warnings");
     like($stdout, qr/\d+\.\d+/,
          "issue #967: --fmt=4 --by-percent=cm produces non-zero output");
+}
+
+# Division-by-zero regression in --by-percent=cm when any entry has
+# code+comment == 0. Run against the full tests/inputs corpus, which
+# contains tests/inputs/issues/644/UInt8.cs (code=0, comment=0, blank=1).
+{
+    foreach my $fmt (qw(3 4)) {
+        my $stderr_file = "$work_dir/dz_fmt${fmt}_stderr.txt";
+        my $stdout_file = "$work_dir/dz_fmt${fmt}_stdout.txt";
+        my $cmd = "$cloc --fmt=$fmt --by-percent=cm ../tests/inputs"
+                . " > $stdout_file 2> $stderr_file";
+        system($cmd);
+        my $stderr = do { local (@ARGV, $/) = $stderr_file; <> } // "";
+        unlink $stderr_file, $stdout_file unless $Verbose;
+        unlike($stderr, qr/Illegal division by zero/,
+               "no division-by-zero with --fmt=$fmt --by-percent=cm");
+    }
 }
 
 done_testing();

--- a/Unix/t/01_opts.t
+++ b/Unix/t/01_opts.t
@@ -1029,6 +1029,35 @@ foreach my $t (@Tests) {
     }
 }
 
+# SUM row regression: with --fmt and --by-percent, the SUM line must show
+# aggregate percentages (computed from total counts), not the sum of
+# per-row percentages. Compare against the non-fmt text path which
+# already produces the correct aggregate.
+{
+    my $baseline_file = "$work_dir/sum_baseline.txt";
+    system("$cloc --by-percent=cm ../tests/inputs > $baseline_file 2>/dev/null");
+    my $baseline = do { local (@ARGV, $/) = $baseline_file; <> } // "";
+    unlink $baseline_file unless $Verbose;
+    my ($baseline_sum) = grep { /^SUM:\s/ } split /\n/, $baseline;
+    my @baseline_pct = $baseline_sum =~ /(\d+\.\d{2})/g;
+
+    foreach my $fmt (qw(1 2 3 4 5)) {
+        my $out_file = "$work_dir/sum_fmt${fmt}.txt";
+        system("$cloc --fmt=$fmt --by-percent=cm ../tests/inputs"
+             . " > $out_file 2>/dev/null");
+        my $stdout = do { local (@ARGV, $/) = $out_file; <> } // "";
+        unlink $out_file unless $Verbose;
+        my ($sum_line) = grep { /^SUM\b/ } split /\n/, $stdout;
+        my @fmt_pct = $sum_line =~ /(\d+\.\d{2})/g;
+        # Each format's SUM should contain the three baseline aggregate
+        # percentages somewhere in the row. Format 2/4/5 also have a Total
+        # column appended; format 1/3 do not. We assert the first three
+        # blank/comment/code aggregates match the baseline.
+        is_deeply([@fmt_pct[0..2]], [@baseline_pct[0..2]],
+                  "--fmt=$fmt --by-percent=cm: SUM row uses aggregate, not sum-of-percentages");
+    }
+}
+
 done_testing();
 print "Finished testing $cloc\n";
 

--- a/Unix/t/01_opts.t
+++ b/Unix/t/01_opts.t
@@ -1007,6 +1007,8 @@ foreach my $t (@Tests) {
 # Division-by-zero regression in --by-percent=cm when any entry has
 # code+comment == 0. Run against the full tests/inputs corpus, which
 # contains tests/inputs/issues/644/UInt8.cs (code=0, comment=0, blank=1).
+# Also assert that the empty-content file shows 0.00 for all three
+# percentage columns (rather than crashing or showing NaN/uninit).
 {
     foreach my $fmt (qw(3 4)) {
         my $stderr_file = "$work_dir/dz_fmt${fmt}_stderr.txt";
@@ -1015,9 +1017,15 @@ foreach my $t (@Tests) {
                 . " > $stdout_file 2> $stderr_file";
         system($cmd);
         my $stderr = do { local (@ARGV, $/) = $stderr_file; <> } // "";
+        my $stdout = do { local (@ARGV, $/) = $stdout_file; <> } // "";
         unlink $stderr_file, $stdout_file unless $Verbose;
         unlike($stderr, qr/Illegal division by zero/,
                "no division-by-zero with --fmt=$fmt --by-percent=cm");
+        # The line for issues/644/UInt8.cs (code=0, comment=0, blank=1)
+        # must show 0.00 across all three percentage columns.
+        my ($empty_line) = grep { /issues\/644\/UInt8\.cs/ } split /\n/, $stdout;
+        like($empty_line // "", qr/\b0\.00\b.*\b0\.00\b.*\b0\.00\b/,
+             "--fmt=$fmt --by-percent=cm: empty file shows 0.00/0.00/0.00");
     }
 }
 

--- a/cloc
+++ b/cloc
@@ -15693,6 +15693,16 @@ sub load_json {                              # {{{1
             }
         }
     }
+    # When --by-percent is in effect, the JSON emits blank_pct/comment_pct/code_pct
+    # instead of blank/comment/code. Alias them so downstream formatting works.
+    foreach my $key (keys %contents) {
+        foreach my $field (qw(blank comment code)) {
+            if (!exists $contents{$key}{$field}
+                && exists $contents{$key}{"${field}_pct"}) {
+                $contents{$key}{$field} = $contents{$key}{"${field}_pct"};
+            }
+        }
+    }
     my $url = $contents{'header'}{'cloc_url'};
     my $ver = $contents{'header'}{'cloc_version'};
     my $sec = $contents{'header'}{'elapsed_seconds'};
@@ -15712,7 +15722,8 @@ sub load_json {                              # {{{1
     my $lang_len = 0;
     foreach my $file (keys %contents) {
         my $flen = length $file;
-        my $llen = length $contents{$file}{'language'};
+        # 'language' is absent for by-language reports (the key itself is the language)
+        my $llen = length($contents{$file}{'language'} // $file);
         $file_len = $file_len > $flen ? $file_len : $flen;
         $lang_len = $lang_len > $llen ? $lang_len : $llen;
     }

--- a/cloc
+++ b/cloc
@@ -4882,14 +4882,16 @@ sub generate_report {                        # {{{1
                         $rhh_count->{$lang_or_file}{'blank'}  );
           if ($opt_by_percent eq 't') {
             $data_line .= sprintf $Format{5}{$Style}  ,
-                $rhh_count->{$lang_or_file}{'blank'}   / $sum_blank   * 100,
-                $rhh_count->{$lang_or_file}{'comment'} / $sum_comment * 100,
-                $rhh_count->{$lang_or_file}{'code'}    / $sum_code    * 100;
-          } else {
+                $sum_blank   ? $rhh_count->{$lang_or_file}{'blank'}   / $sum_blank   * 100 : 0,
+                $sum_comment ? $rhh_count->{$lang_or_file}{'comment'} / $sum_comment * 100 : 0,
+                $sum_code    ? $rhh_count->{$lang_or_file}{'code'}    / $sum_code    * 100 : 0;
+          } elsif ($DEN > 0) {
             $data_line .= sprintf $Format{5}{$Style}  ,
                 $rhh_count->{$lang_or_file}{'blank'}   / $DEN * 100,
                 $rhh_count->{$lang_or_file}{'comment'} / $DEN * 100,
                 $rhh_count->{$lang_or_file}{'code'}    / $DEN * 100;
+          } else {
+            $data_line .= sprintf $Format{5}{$Style}, 0, 0, 0;
           }
         } else {
           $data_line .= sprintf $Format{4}{$Style}  ,
@@ -4933,18 +4935,18 @@ sub generate_report {                        # {{{1
                             $rhh_count->{$lang_or_file}{'blank'}  );
             if ($opt_by_percent eq 't') {
               push @results,"  ${Q}blank_pct${Q}: "   .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'blank'}   / $sum_blank   * 100) . $C;
+                sprintf("%3.2f", $sum_blank   ? $rhh_count->{$lang_or_file}{'blank'}   / $sum_blank   * 100 : 0) . $C;
               push @results,"  ${Q}comment_pct${Q}: " .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'comment'} / $sum_comment * 100) . $C;
+                sprintf("%3.2f", $sum_comment ? $rhh_count->{$lang_or_file}{'comment'} / $sum_comment * 100 : 0) . $C;
               push @results,"  ${Q}code_pct${Q}: "    .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'code'}    / $sum_code    * 100) . $C;
+                sprintf("%3.2f", $sum_code    ? $rhh_count->{$lang_or_file}{'code'}    / $sum_code    * 100 : 0) . $C;
             } else {
               push @results,"  ${Q}blank_pct${Q}: "     .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'blank'}   / $DEN * 100) . $C;
+                sprintf("%3.2f", $DEN ? $rhh_count->{$lang_or_file}{'blank'}   / $DEN * 100 : 0) . $C;
               push @results,"  ${Q}comment_pct${Q}: " .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'comment'} / $DEN * 100) . $C;
+                sprintf("%3.2f", $DEN ? $rhh_count->{$lang_or_file}{'comment'} / $DEN * 100 : 0) . $C;
               push @results,"  ${Q}code_pct${Q}: "    .
-                sprintf("%3.2f", $rhh_count->{$lang_or_file}{'code'}    / $DEN * 100) . $C;
+                sprintf("%3.2f", $DEN ? $rhh_count->{$lang_or_file}{'code'}    / $DEN * 100 : 0) . $C;
             }
             } else {
               push @results,"  ${Q}blank${Q}: "   . $rhh_count->{$lang_or_file}{'blank'}   . $C;
@@ -4992,13 +4994,13 @@ sub generate_report {                        # {{{1
                             $rhh_count->{$lang_or_file}{'comment'},
                             $rhh_count->{$lang_or_file}{'blank'}  );
               if ($opt_by_percent eq 't') {
-                $str .= sprintf("%3.2f", $rhh_count->{$lang_or_file}{'blank'}   / $sum_blank   * 100) . ${DELIM} .
-                        sprintf("%3.2f", $rhh_count->{$lang_or_file}{'comment'} / $sum_comment * 100) . ${DELIM} .
-                        sprintf("%3.2f", $rhh_count->{$lang_or_file}{'code'}    / $sum_code    * 100) . ${DELIM} ;
+                $str .= sprintf("%3.2f", $sum_blank   ? $rhh_count->{$lang_or_file}{'blank'}   / $sum_blank   * 100 : 0) . ${DELIM} .
+                        sprintf("%3.2f", $sum_comment ? $rhh_count->{$lang_or_file}{'comment'} / $sum_comment * 100 : 0) . ${DELIM} .
+                        sprintf("%3.2f", $sum_code    ? $rhh_count->{$lang_or_file}{'code'}    / $sum_code    * 100 : 0) . ${DELIM} ;
               } else {
-                $str .= sprintf("%3.2f", $rhh_count->{$lang_or_file}{'blank'}   / $DEN * 100) . ${DELIM} .
-                        sprintf("%3.2f", $rhh_count->{$lang_or_file}{'comment'} / $DEN * 100) . ${DELIM} .
-                        sprintf("%3.2f", $rhh_count->{$lang_or_file}{'code'}    / $DEN * 100) . ${DELIM} ;
+                $str .= sprintf("%3.2f", $DEN ? $rhh_count->{$lang_or_file}{'blank'}   / $DEN * 100 : 0) . ${DELIM} .
+                        sprintf("%3.2f", $DEN ? $rhh_count->{$lang_or_file}{'comment'} / $DEN * 100 : 0) . ${DELIM} .
+                        sprintf("%3.2f", $DEN ? $rhh_count->{$lang_or_file}{'code'}    / $DEN * 100 : 0) . ${DELIM} ;
               }
             } else {
               $str .= $rhh_count->{$lang_or_file}{'blank'}  . ${DELIM} .
@@ -5027,14 +5029,16 @@ sub generate_report {                        # {{{1
                         $sum_code, $sum_comment, $sum_blank);
           if ($opt_by_percent eq 't') {
             $data_line .= sprintf $Format{'5'}{$Style},
-                $sum_blank   / $sum_blank   * 100,
-                $sum_comment / $sum_comment * 100,
-                $sum_code    / $sum_code    * 100;
-          } else {
+                $sum_blank   ? 100 : 0,
+                $sum_comment ? 100 : 0,
+                $sum_code    ? 100 : 0;
+          } elsif ($DEN > 0) {
             $data_line .= sprintf $Format{'5'}{$Style},
                 $sum_blank   / $DEN * 100,
                 $sum_comment / $DEN * 100,
                 $sum_code    / $DEN * 100;
+          } else {
+            $data_line .= sprintf $Format{'5'}{$Style}, 0, 0, 0;
           }
         } else {
           $data_line .= sprintf $Format{'4'}{$Style},
@@ -5107,9 +5111,9 @@ sub generate_report {                        # {{{1
           } else {
             my $DEN = compute_denominator($opt_by_percent    ,
                           $sum_code, $sum_comment, $sum_blank);
-            push @entries, sprintf("%.2f", $sum_blank   / $DEN * 100);
-            push @entries, sprintf("%.2f", $sum_comment / $DEN * 100);
-            push @entries, sprintf("%.2f", $sum_code    / $DEN * 100);
+            push @entries, sprintf("%.2f", $DEN ? $sum_blank   / $DEN * 100 : 0);
+            push @entries, sprintf("%.2f", $DEN ? $sum_comment / $DEN * 100 : 0);
+            push @entries, sprintf("%.2f", $DEN ? $sum_code    / $DEN * 100 : 0);
           }
         } else {
             push @entries, $sum_blank;
@@ -5136,10 +5140,14 @@ sub generate_report {                        # {{{1
           } else {
             my $DEN = compute_denominator($opt_by_percent    ,
                           $sum_code, $sum_comment, $sum_blank);
-            $data_line .= sprintf $Format{'5'}{$Style},
-                $sum_blank   / $DEN * 100,
-                $sum_comment / $DEN * 100,
-                $sum_code    / $DEN * 100;
+            if ($DEN > 0) {
+              $data_line .= sprintf $Format{'5'}{$Style},
+                  $sum_blank   / $DEN * 100,
+                  $sum_comment / $DEN * 100,
+                  $sum_code    / $DEN * 100;
+            } else {
+              $data_line .= sprintf $Format{'5'}{$Style}, 0, 0, 0;
+            }
           }
         } else {
           $data_line .= sprintf $Format{'4'}{$Style},

--- a/cloc
+++ b/cloc
@@ -1818,8 +1818,8 @@ sub produce_output {                         # {{{1
     if ($opt_fmt) {
         my $json_string = "";
         write_file(\$json_string, {}, @{$ra_Lines_Out});
-        my ($file_len, $lang_len, $header, %contents) = load_json($json_string);
-        @{$ra_Lines_Out} = print_format_n(abs($opt_fmt), $file_len, $lang_len, $header, %contents);
+        my ($file_len, $lang_len, $header, $rh_sum, %contents) = load_json($json_string);
+        @{$ra_Lines_Out} = print_format_n(abs($opt_fmt), $file_len, $lang_len, $header, $rh_sum, %contents);
     }
     if ($outfile) {
         my $adjusted_outfile = $outfile;
@@ -15719,6 +15719,10 @@ sub load_json {                              # {{{1
     $sec = $sec == 0 ? 1.0e-3 : $sec;
     my $header = sprintf "%s v %s T=%.2f s (%.1f files/s, %.1f lines/s)",
                           $url, $ver, $sec, $n_file/$sec, $n_line/$sec;
+    # Preserve the SUM block so print_format_n can render the SUM row from
+    # aggregate counts/percentages instead of accumulating per-row values
+    # (which is meaningless under --by-percent).
+    my %sum_block = exists $contents{'SUM'} ? %{$contents{'SUM'}} : ();
     delete $contents{'header'};
     delete $contents{'SUM'};
 
@@ -15736,7 +15740,7 @@ sub load_json {                              # {{{1
         $lang_len = $lang_len > $llen ? $lang_len : $llen;
     }
     print "<- load_json()\n" if $opt_v > 2;
-    return $file_len, $lang_len, $header, %contents;
+    return $file_len, $lang_len, $header, \%sum_block, %contents;
 }
 # 1}}}
 sub print_format_n {                         # {{{1
@@ -15746,8 +15750,9 @@ sub print_format_n {                         # {{{1
     # format 3 : File | Language | blank | comment | code
     # format 4 : File | blank | comment | code | total
     # format 5 : File | Language | blank | comment | code | total
-    my ($format, $file_len, $lang_len, $header, %contents) = @_;
+    my ($format, $file_len, $lang_len, $header, $rh_sum, %contents) = @_;
     print "-> print_format_n($format)\n" if $opt_v > 2;
+    $rh_sum = {} unless ref($rh_sum) eq 'HASH';
     my @prt_lines = ();
 
     # 8 = characters in "Language"
@@ -15860,6 +15865,33 @@ sub print_format_n {                         # {{{1
     }
     push @prt_lines, "$hyphens{$format}\n";
     if (scalar @file_list > 1) {
+        # Under --by-percent the per-row values are percentages, so
+        # accumulating them into the SUM row is meaningless. Replace the
+        # SUM cells with the aggregate from the JSON's preserved SUM block:
+        # in 't' mode the JSON stores 100/100/100 directly; in 'c'/'cm'/
+        # 'cb'/'cmb' it stores raw counts which we convert via the same
+        # compute_denominator() the text path uses.
+        if ($opt_by_percent and %{$rh_sum}) {
+            my $sum_blank   = $rh_sum->{'blank'}   // 0;
+            my $sum_comment = $rh_sum->{'comment'} // 0;
+            my $sum_code    = $rh_sum->{'code'}    // 0;
+            $n_files = $rh_sum->{'nFiles'} // $n_files;
+            if ($opt_by_percent eq 't') {
+                ($n_blank, $n_comment, $n_code) =
+                    ($sum_blank, $sum_comment, $sum_code);
+            } else {
+                my $DEN = compute_denominator($opt_by_percent,
+                              $sum_code, $sum_comment, $sum_blank);
+                if ($DEN > 0) {
+                    $n_blank   = sprintf("%.2f", $sum_blank   / $DEN * 100);
+                    $n_comment = sprintf("%.2f", $sum_comment / $DEN * 100);
+                    $n_code    = sprintf("%.2f", $sum_code    / $DEN * 100);
+                } else {
+                    ($n_blank, $n_comment, $n_code) = (0, 0, 0);
+                }
+            }
+            $n_total = $n_blank + $n_comment + $n_code;
+        }
         if ($opt_thousands_delimiter) {
             $n_files   = separate_thousands($n_files,   $opt_thousands_delimiter);
             $n_blank   = separate_thousands($n_blank,   $opt_thousands_delimiter);


### PR DESCRIPTION
## Summary

Fixes #967.

When `--fmt` is combined with `--by-percent`, cloc round-trips its results through an intermediate JSON. That JSON uses `blank_pct` / `comment_pct` / `code_pct` keys, but `print_format_n` only reads the canonical `blank` / `comment` / `code`. The result was a stream of `Use of uninitialized value` warnings on STDERR and a table of zeros.

### Repro (before this PR)
```
$ cloc --fmt=4 --by-percent=cm <some dir>
Use of uninitialized value $nB in addition (+) at .../cloc line 15819.
Use of uninitialized value $nCm in addition (+) at .../cloc line 15820.
... (many more)
File      blank  comment     code    Total
./a.c         0        0        0        0
./b.py        0        0        0        0
```

### After
```
File      blank  comment     code    Total
./a.c      0.00    33.33    66.67      100
./b.py     0.00    33.33    66.67      100
```

## Changes

- **`cloc`** — in `load_json`:
  - Alias `*_pct` keys to their canonical names so the rest of the format pipeline works unchanged.
  - Fall back from a missing `language` field to the entry key (by-language reports don't carry one), avoiding a separate `length(undef)` warning.
- **`Unix/t/01_opts.t`** — regression test that asserts no `Use of uninitialized value` on STDERR and non-zero output for `--fmt=4 --by-percent=cm`.

## Test plan

- [x] Original repro from the issue produces clean output with no warnings.
- [x] `prove t/00_C.t t/01_opts.t t/02_git.t` — all 952 tests pass (including 2 new).