### PR TITLE
Improve support for the C3 language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,6 +1049,7 @@ C#                         (cs)
 C# Designer                (designer.cs)
 C++                        (C, c++, c++m, cc, ccm, CPP, cpp, cppm, cxx, cxxm, h++, inl, ipp,
                             ixx, pcc, tcc, tpp)
+C3                         (c3, c3i, c3t)
 C/C++ Header               (H, h, hh, hpp, hxx)
 Cadence                    (cdc)
 Cairo                      (cairo)

--- a/cloc
+++ b/cloc
@@ -10260,9 +10260,13 @@ sub set_constants {                          # {{{1
                             ],
     'C3'                 => [
                                 [ 'remove_matches'      , '^\s*//' ],
+                                [ 'rm_comments_in_strings', '"', '/*', '*/' ],
+                                [ 'rm_comments_in_strings', '`', '/*', '*/', 1 ],
+                                [ 'rm_comments_in_strings', '`', '//', '', 1 ],
+                                [ 'rm_comments_in_strings', '`', '<*', '*>', 1 ],
+                                [ 'remove_between_general', '/*', '*/' ],
                                 [ 'remove_between_general', '<*', '*>' ],
                                 [ 'call_regexp_common'  , 'C++'    ],
-                                [ 'remove_inline'       , '//.*$'  ],
                             ],
     'D/dtrace'           => [ [ 'die' ,          ], ], # never called
     'D'                  => [

--- a/tests/inputs/io.c3
+++ b/tests/inputs/io.c3
@@ -161,3 +161,13 @@ fn usz? readline_to_stream_impl(OStream out_stream, IStream in_stream, usz limit
 	return len;
 }
 
+
+// Additional tests for cloc
+char *raw = `multiline
+raw string with // and /*
+markers inside`;
+
+/* Unfinished block comment at the end of the file
+
+these are valid in c3
+

--- a/tests/outputs/io.c3.yaml
+++ b/tests/outputs/io.c3.yaml
@@ -3,19 +3,19 @@
 header : 
   cloc_url           : github.com/AlDanial/cloc
   cloc_version       : 2.09
-  elapsed_seconds    : 0.00584793090820312
+  elapsed_seconds    : 0.00552797317504883
   n_files            : 1
-  n_lines            : 163
-  files_per_second   : 171.000652315721
-  lines_per_second   : 27873.1063274625
+  n_lines            : 173
+  files_per_second   : 180.898128180799
+  lines_per_second   : 31295.3761752782
   report_file        : ../outputs/io.c3.yaml
 'C3' :
   nFiles: 1
-  blank: 13
-  comment: 36
-  code: 114
+  blank: 17
+  comment: 40
+  code: 116
 SUM: 
-  blank: 13
-  comment: 36
-  code: 114
+  blank: 17
+  comment: 40
+  code: 116
   nFiles: 1


### PR DESCRIPTION
Thanks again @AlDanial for merging [C3](https://github.com/AlDanial/cloc/commit/4e7368eea7608ea23dc636fdc1e66ba3969d6892) support into cloc! This is just a quick update to handle a few remaining cases for completeness:

- Handle unfinished block comments `/*` at EOF ([example](https://github.com/c3lang/c3c/blob/master/test/test_suite/bitstruct/bitstruct_arrays.c3t))
- Add support for backtick raw multiline strings ([example](https://github.com/c3lang/c3c/blob/master/resources/examples/http_server.c3#L475))
- Update README and update regression test.