### PR TITLE
Support .inc assembly files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,7 +1270,7 @@ Pek                        (pek)
 Perl                       (ack, al, cpanfile, makefile.pl, perl, ph, plh, plx, pm, psgi, rexfile, pl, p6)
 Pest                       (pest)
 PHP                        (aw, ctp, phakefile, php, php3, php4, php5, php_cs, php_cs.dist, phps, phpt, phtml)
-PHP/Pascal/Fortran/Pawn/BitBake (inc)
+PHP/Pascal/Fortran/Pawn/BitBake/Assembly (inc)
 Pig Latin                  (pig)
 Pkl                        (pkl)
 PL/I                       (pl1)
@@ -1452,7 +1452,7 @@ These file extensions map to multiple languages:
 *   `fnc` files could be Oracle PL or SQL
 *   `for` files could be Fortran 77 or Forth
 *   `fs`  files could be F# or Forth
-*   `inc` files could be PHP, Pascal or BitBake
+*   `inc` files could be PHP, Pascal, Fortran, Pawn, BitBake or Assembly
 *   `itk` files could be Tcl or Tk
 *   `jl`  files could be Lisp or Julia
 *   `lit` files could be PL or M

--- a/Unix/t/00_C.t
+++ b/Unix/t/00_C.t
@@ -1003,6 +1003,7 @@ my @Tests = (
                               '../tests/inputs/hanoi.inc ' .
                               '../tests/inputs/pascal.inc ' .
                               '../tests/inputs/test1.inc ' .
+                              '../tests/inputs/assembly.inc ' .
                               '../tests/inputs/Pascal.p ' .
                               '../tests/inputs/queue.p ',
                 },

--- a/cloc
+++ b/cloc
@@ -829,7 +829,7 @@ my %Extension_Collision = (
     'Pascal/Pawn'                                   => [ 'p'    ] ,
     'Pascal/Puppet'                                 => [ 'pp'   ] ,
     'Perl/Prolog'                                   => [ 'pl', 'PL'  ] ,
-    'PHP/Pascal/Fortran/Pawn/BitBake'               => [ 'inc'  ] ,
+    'PHP/Pascal/Fortran/Pawn/BitBake/Assembly'      => [ 'inc'  ] ,
     'Raku/Prolog'                                   => [ 'p6', 'P6'  ] ,
     'XML-Qt-GTK/Glade'                              => [ 'ui'   ] ,
     'TypeScript/Qt Linguist'                        => [ 'ts'   ] ,
@@ -6866,17 +6866,17 @@ sub classify_file {                          # {{{1
                         'failure in matlab_or_objective_C($full_file)';
                     return $language; # (unknown)
                 }
-            } elsif ($Language_by_Extension{$extension} eq 'PHP/Pascal/Fortran/Pawn/BitBake') {
-                my $lang_F_or_P_or_P_or_B = "";
-                php_pascal_fortran_pawn_bitbake($full_file ,
+            } elsif ($Language_by_Extension{$extension} eq 'PHP/Pascal/Fortran/Pawn/BitBake/Assembly') {
+                my $lang_F_or_P_or_P_or_B_or_A = "";
+                php_pascal_fortran_pawn_bitbake_assembly($full_file ,
                                         $rh_Err    ,
                                         $raa_errors,
-                                       \$lang_F_or_P_or_P_or_B);
-                if ($lang_F_or_P_or_P_or_B) {
-                    return $lang_F_or_P_or_P_or_B;
-                } else { # an error happened in php_pascal_fortran_pawn_bitbake()
+                                       \$lang_F_or_P_or_P_or_B_or_A);
+                if ($lang_F_or_P_or_P_or_B_or_A) {
+                    return $lang_F_or_P_or_P_or_B_or_A;
+                } else { # an error happened in php_pascal_fortran_pawn_bitbake_assembly()
                     $rh_ignored->{$full_file} =
-                        'failure in php_pascal_fortran_pawn_bitbake($full_file)';
+                        'failure in php_pascal_fortran_pawn_bitbake_assembly($full_file)';
                     return $language; # (unknown)
                 }
             } elsif ($Language_by_Extension{$extension} eq 'Pascal/Puppet') {
@@ -9184,7 +9184,7 @@ sub set_constants {                          # {{{1
             'ig'          => 'Modula3'               ,
             'il'          => 'SKILL/.NET IL'         ,
             'ils'         => 'SKILL++'               ,
-            'inc'         => 'PHP/Pascal/Fortran/Pawn/BitBake' ,
+            'inc'         => 'PHP/Pascal/Fortran/Pawn/BitBake/Assembly' ,
             'ino'         => 'Arduino Sketch'        ,
             'ipf'         => 'Igor Pro'              ,
            #'pde'         => 'Arduino Sketch'        , # pre 1.0
@@ -10963,7 +10963,7 @@ sub set_constants {                          # {{{1
                                 [ 'rm_comments_in_strings', '"', '//', '' ],
                                 [ 'call_regexp_common'  , 'C++'    ],
                             ],
-    'PHP/Pascal/Fortran/Pawn/BitBake' => [ [ 'die' ,          ], ], # never called
+    'PHP/Pascal/Fortran/Pawn/BitBake/Assembly' => [ [ 'die' ,          ], ], # never called
     'Mako'               => [
                                 [ 'remove_matches'       , '##.*$'  ],
                             ],
@@ -12479,7 +12479,7 @@ sub set_constants {                          # {{{1
     'Fortran 77/Forth'                => 1.00,
     'Lisp/Julia'                      => 1.00,
     'Lisp/OpenCL'                     => 1.00,
-    'PHP/Pascal/Fortran/Pawn/Bitbake' => 1.00,
+    'PHP/Pascal/Fortran/Pawn/Bitbake/Assembly' => 1.00,
     'Pascal/Puppet'                   => 1.00,
     'Perl/Prolog'                     => 1.00,
     'Raku/Prolog'                     => 1.00,
@@ -12753,8 +12753,8 @@ printf "END LOOP    obj C=% 2d  matlab=% 2d  mumps=% 2d  mercury= % 2d\n", $obje
         if $opt_v > 2;
 
 } # 1}}}
-sub php_pascal_fortran_pawn_bitbake {                # {{{1
-    # Decide if code is Fortran, PHP, Pascal, Pawn
+sub php_pascal_fortran_pawn_bitbake_assembly {                # {{{1
+    # Decide if code is Fortran, PHP, Pascal, Pawn, Assembly
     my ($file        , # in
         $rh_Err      , # in   hash of error codes
         $raa_errors  , # out
@@ -12788,6 +12788,10 @@ sub php_pascal_fortran_pawn_bitbake {                # {{{1
     #   some lines start with include, require, inherit statements
     #   contains .=, =., ?=, ??= operators
     #   contains :... = assignments
+	#
+	# Assembly:
+	#   lines may start with: org/.org, section/.section, segment, %include/.include/include, macro/.macro/%macro/.endm/%endmacro (some nasm/fasm/gas/masm directives)
+	#   lines may start with: mov, push, pop, add, jmp, call, ret (common assembly instructions)
 
     ${$rs_language} = "";
     my $IN = open_file('<', $file, 1);
@@ -12804,6 +12808,7 @@ sub php_pascal_fortran_pawn_bitbake {                # {{{1
     my $pascal_points   = 0;
     my $pawn_points     = 0;
     my $bitbake_points  = 0;
+    my $assembly_points = 0;
     while (<$IN>) {
         if (/^\s*<\?php/i) {
             $php_points += 100;
@@ -12836,7 +12841,13 @@ sub php_pascal_fortran_pawn_bitbake {                # {{{1
         } elsif (/^\@/ or /^\s*(Float:|bool:)/) {
             $pawn_points += 1e+20;
             last;
-        }
+        } elsif (/^\s*(\%include|\.include|include)\b/i or
+                 /^\s*(segment|section|\.section)\b/i   or
+                 /^\s*(macro|\.macro|\%macro|\%endmacro|\.endm)\b/i   or
+                 /^\s*(\.org|org)\b/i) {
+            $assembly_points += 100;
+            last;
+		}
         if (/^\s*(integer|real|complex|double|character|logical|public|private).*?::/i or
             /^\s*(allocatable|dimension)/i or
             /^\s*(end\s+)?(interface|type|function|module)\b/i) {
@@ -12853,6 +12864,9 @@ sub php_pascal_fortran_pawn_bitbake {                # {{{1
         if (/^[A-Z0-9_:-]+:[A-Za-z0-9_-]+\s*=/) {
             ++$bitbake_points;
         }
+        if (/^\s*(mov|push|pop|add|jmp|call|ret)\b/i) {
+            ++$assembly_points;
+        }
     }
     $IN->close;
 
@@ -12860,7 +12874,8 @@ sub php_pascal_fortran_pawn_bitbake {                # {{{1
                    'PHP'          => $php_points         ,
                    'Pascal'       => $pascal_points      ,
                    'Pawn'         => $pawn_points        ,
-                   'BitBake'      => $bitbake_points     , );
+                   'BitBake'      => $bitbake_points     ,
+                   'Assembly'     => $assembly_points    , );
 
     ${$rs_language} = (sort { $points{$b} <=> $points{$a} or $a cmp $b } keys %points)[0];
     if (${$rs_language} eq 'Fortran') {
@@ -12871,8 +12886,8 @@ sub php_pascal_fortran_pawn_bitbake {                # {{{1
         }
     }
 
-    print "<- php_pascal_fortran_pawn_bitbake($file: fortran=$fortran_points, php=$php_points, ",
-          "pascal=$pascal_points, pawn=$pawn_points, bitbake=$bitbake_points) => ${$rs_language}\n"
+    print "<- php_pascal_fortran_pawn_bitbake_assembly($file: fortran=$fortran_points, php=$php_points, ",
+          "pascal=$pascal_points, pawn=$pawn_points, bitbake=$bitbake_points, assembly=$assembly_points) => ${$rs_language}\n"
         if $opt_v > 2;
 
 } # 1}}}

--- a/tests/inputs/assembly.inc
+++ b/tests/inputs/assembly.inc
@@ -1,0 +1,22 @@
+; simple Flat Assembler macros
+
+SYS_EXIT = 60
+SYS_WRITE = 1
+
+EXIT_CODE = 255
+
+SYS_STDOUT = 1
+
+macro PRINT str_address, len {
+	mov rax, SYS_WRITE
+	mov rdi, SYS_STDOUT
+	mov rsi, str_address
+	mov rdx, len
+	syscall
+}
+
+macro EXIT {
+	mov rax, SYS_EXIT
+	mov rdi, EXIT_CODE
+	syscall
+}

--- a/tests/outputs/pawn.yaml
+++ b/tests/outputs/pawn.yaml
@@ -2,13 +2,13 @@
 # github.com/AlDanial/cloc
 header : 
   cloc_url           : github.com/AlDanial/cloc
-  cloc_version       : 2.01
-  elapsed_seconds    : 0.00428891181945801
-  n_files            : 6
-  n_lines            : 165
-  files_per_second   : 1398.9562510423
-  lines_per_second   : 38471.2969036634
-  report_file        : ../outputs/pawn.yaml
+  cloc_version       : 2.11
+  elapsed_seconds    : 0.00733709335327148
+  n_files            : 7
+  n_lines            : 187
+  files_per_second   : 954.056281276402
+  lines_per_second   : 25486.9320855267
+  report_file        : tests/outputs/pawn.yaml
 'Pawn' :
   nFiles: 2
   blank: 16
@@ -19,6 +19,11 @@ header :
   blank: 4
   comment: 4
   code: 20
+'Assembly' :
+  nFiles: 1
+  blank: 5
+  comment: 1
+  code: 16
 'Pascal' :
   nFiles: 2
   blank: 2
@@ -30,7 +35,7 @@ header :
   comment: 7
   code: 11
 SUM: 
-  blank: 27
-  comment: 29
-  code: 109
-  nFiles: 6
+  blank: 32
+  comment: 30
+  code: 125
+  nFiles: 7


### PR DESCRIPTION
It's common to have Assembly files with .inc extension. In most cases, they contain macros/constants to be included in other files.

cloc was treating those files as another language. This PR addresses this problem by checking for some common assembler directives and assembly instructions.

( a .inc test file was included inside Pawn's args since other inc conflicts were there too )