### PR TITLE
ci: read the branch name from the environment instead of interpolating it into PowerShell

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -19,9 +19,12 @@ jobs:
       - name: Extract version from branch name
         id: get_version
         shell: pwsh
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          GH_REF: ${{ github.ref }}
         run: |
-          $branch = "${{ github.head_ref }}"
-          if (-not $branch) { $branch = "${{ github.ref }}" }
+          $branch = $env:HEAD_REF
+          if (-not $branch) { $branch = $env:GH_REF }
           if ($branch -match 'release-v(?<ver>[0-9]+\.[0-9]+)') {
             $ver = $Matches["ver"]
             echo "VERSION_NUM=$ver" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Hi, and thanks for cloc.

In `.github/workflows/release-staging.yml`, the branch name is interpolated into the PowerShell script:

```powershell
$branch = "${{ github.head_ref }}"
if (-not $branch) { $branch = "${{ github.ref }}" }
```

Actions substitutes `${{ ... }}` into the script text before PowerShell parses it, so the branch name becomes part of the script rather than a string. PowerShell expands `$(...)` inside double-quoted strings, and git allows `$`, `(` and `)` in branch names — so a PR from a fork on a branch named something like `release-v1.0$(...)` would run that instead of being matched by the regex below.

To be fair about the size of it: this is `pull_request`, so a fork PR gets a read-only token and no secrets. I am raising it as hardening rather than as a live exploit.

The change reads both values from the environment, which is PowerShell's equivalent of the same fix:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
  GH_REF: ${{ github.ref }}
run: |
  $branch = $env:HEAD_REF
  if (-not $branch) { $branch = $env:GH_REF }
```

The `release-v(?<ver>[0-9]+\.[0-9]+)` match and the `$Matches["ver"]` extraction below are untouched, so version detection behaves exactly as before.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
